### PR TITLE
fix: update unread counter with fastening markers ref: WSC-1747

### DIFF
--- a/src/chats/components/creationModal/ListParticipant.tsx
+++ b/src/chats/components/creationModal/ListParticipant.tsx
@@ -81,6 +81,7 @@ const ListParticipant = ({
 							data-testid={`checkbox-chip-${item.email}`}
 							value={selected}
 							disabled={!selected && isDisabled}
+							iconColor={selected ? 'primary' : 'gray0'}
 						/>
 						<Padding horizontal="small">
 							<Avatar label={item.displayName} picture={picture} />

--- a/src/store/slices/UnreadsCounterStoreSlice.test.ts
+++ b/src/store/slices/UnreadsCounterStoreSlice.test.ts
@@ -7,10 +7,18 @@
 import { act, renderHook } from '@testing-library/react';
 import { size } from 'lodash';
 
+import {
+	createMockConfigurationMessage,
+	createMockMarker,
+	createMockTextMessage
+} from '../../tests/createMock';
 import useStore from '../Store';
 
+beforeEach(() => {
+	useStore.getState().setLoginInfo('sessionUser', 'Session User');
+});
 describe('Test unreadsCounter slice', () => {
-	it('add unreadsCounters to the list and check total rooms with unreads', () => {
+	test('Add unreadsCounters to the list and check total rooms with unreads', () => {
 		const { result } = renderHook(() => useStore());
 		act(() => result.current.addUnreadCount('roomOne', 5));
 		expect(result.current.unreads.roomOne).toBe(5);
@@ -19,11 +27,80 @@ describe('Test unreadsCounter slice', () => {
 		expect(result.current.unreads.roomTwo).toBe(10);
 		expect(size(result.current.unreads)).toBe(2);
 	});
-	it('increment an unread counter of a room', () => {
+
+	test('Increment an unread counter of a room', () => {
 		const { result } = renderHook(() => useStore());
 		act(() => result.current.addUnreadCount('roomOne', 5));
 		expect(result.current.unreads.roomOne).toBe(5);
 		act(() => result.current.incrementUnreadCount('roomOne'));
 		expect(result.current.unreads.roomOne).toBe(6);
+	});
+
+	test('Update unreads counter of a room without messages and markers', () => {
+		useStore.setState({
+			messages: { roomOne: [] },
+			markers: { roomOne: {} }
+		});
+		const { result } = renderHook(() => useStore());
+		act(() => result.current.updateUnreadCount('roomOne'));
+		expect(result.current.unreads.roomOne).toBe(0);
+	});
+
+	test('Update unreads counter of a room with messages but no markers', () => {
+		useStore.setState({
+			messages: {
+				roomOne: [
+					createMockConfigurationMessage(),
+					createMockTextMessage({ from: 'sessionUser' }),
+					createMockTextMessage({ from: 'userOne' })
+				]
+			},
+			markers: { roomOne: {} }
+		});
+		const { result } = renderHook(() => useStore());
+		act(() => result.current.updateUnreadCount('roomOne'));
+		expect(result.current.unreads.roomOne).toBe(2);
+	});
+
+	test('Update unreads counter of a room with session marker', () => {
+		const now = Date.now();
+		useStore.setState({
+			messages: {
+				roomOne: [
+					createMockConfigurationMessage({ id: 'msg1', date: now - 5000 }),
+					createMockTextMessage({ id: 'msg2', from: 'sessionUser', date: now - 4000 }),
+					createMockTextMessage({ id: 'msg1', from: 'userOne', date: now - 3000 })
+				]
+			},
+			markers: {
+				roomOne: {
+					sessionUser: createMockMarker({ messageId: 'msg1' })
+				}
+			}
+		});
+		const { result } = renderHook(() => useStore());
+		act(() => result.current.updateUnreadCount('roomOne'));
+		expect(result.current.unreads.roomOne).toBe(1);
+	});
+
+	test('Update unreads counter of a room with session marker of a message that does not exist or it refers to a fastening', () => {
+		const now = Date.now();
+		useStore.setState({
+			messages: {
+				roomOne: [
+					createMockConfigurationMessage({ id: 'msg1', date: now - 5000 }),
+					createMockTextMessage({ id: 'msg2', from: 'sessionUser', date: now - 4000 }),
+					createMockTextMessage({ id: 'msg1', from: 'userOne', date: now - 3000 })
+				]
+			},
+			markers: {
+				roomOne: {
+					sessionUser: createMockMarker({ messageId: 'fastening1', markerDate: now - 2000 })
+				}
+			}
+		});
+		const { result } = renderHook(() => useStore());
+		act(() => result.current.updateUnreadCount('roomOne'));
+		expect(result.current.unreads.roomOne).toBe(0);
 	});
 });

--- a/src/store/slices/UnreadsCounterStoreSlice.ts
+++ b/src/store/slices/UnreadsCounterStoreSlice.ts
@@ -8,6 +8,7 @@ import { produce } from 'immer';
 import { filter, find, size } from 'lodash';
 import { StateCreator } from 'zustand';
 
+import { isMyId } from '../../network/websocket/eventHandlersUtilities';
 import { Message, MessageType } from '../../types/store/MessageTypes';
 import { RootStore, UnreadsCounterSlice } from '../../types/store/StoreTypes';
 import { isBefore } from '../../utils/dateUtils';
@@ -39,21 +40,29 @@ export const useUnreadsCountStoreSlice: StateCreator<UnreadsCounterSlice> = (
 	updateUnreadCount: (roomId: string): void => {
 		set(
 			produce((draft: RootStore) => {
+				const messages = draft.messages[roomId];
 				const lastMarker =
 					draft.markers[roomId] &&
 					draft.session.id !== undefined &&
 					draft.markers[roomId][draft.session.id];
 				const lastMarkedMessage = find(
-					draft.messages[roomId],
+					messages,
 					(message: Message) => lastMarker && message.id === lastMarker.messageId
 				);
+				const isConfigurationMessage = (type: MessageType): boolean =>
+					type === MessageType.CONFIGURATION_MSG;
+				const isTextMessageFromOther = (message: Message): boolean =>
+					message.type === MessageType.TEXT_MSG && !isMyId(message.from);
+				const isAfterLastMarker = (date: number): boolean => {
+					if (!lastMarker) return true;
+					const dateToCompare = lastMarkedMessage ? lastMarkedMessage.date : lastMarker.markerDate;
+					return !isBefore(date, dateToCompare);
+				};
 				const unreadByMe = filter(
-					draft.messages[roomId],
+					messages,
 					(message) =>
-						(message.type === MessageType.CONFIGURATION_MSG ||
-							(message.type === MessageType.TEXT_MSG && message.from !== draft.session.id)) &&
-						(!lastMarkedMessage ||
-							(lastMarkedMessage && !isBefore(message.date, lastMarkedMessage.date)))
+						(isConfigurationMessage(message.type) || isTextMessageFromOther(message)) &&
+						isAfterLastMarker(message.date)
 				);
 				draft.unreads[roomId] = size(unreadByMe);
 			}),

--- a/src/utils/calcReads.ts
+++ b/src/utils/calcReads.ts
@@ -28,7 +28,8 @@ export function calcReads(messageDate: number, roomId: string): MarkerStatus {
 				roomMessages,
 				(message: Message) => message.id === marker.messageId
 			) as TextMessage;
-			if (marker.from !== sessionId && markedMessage && isBefore(messageDate, markedMessage.date)) {
+			const dateToCompare = markedMessage?.date || marker.markerDate;
+			if (marker.from !== sessionId && isBefore(messageDate, dateToCompare)) {
 				readBy.push(userId);
 			}
 		});


### PR DESCRIPTION
`updateUnreadCount` and `calcReads` methods are been updated so if the `messageId` of the last marker isn’t associated with any text message, it uses the marker’s date to determine if messages are still unread.
This change addresses a specific case on mobile, where markers refer to reaction fastenings.