### PR TITLE
fix: meeting chat title overflow ref: WSC-1820

### DIFF
--- a/src/meetings/components/sidebar/MeetingConversationAccordion/MeetingChatAccordionTitle.tsx
+++ b/src/meetings/components/sidebar/MeetingConversationAccordion/MeetingChatAccordionTitle.tsx
@@ -5,7 +5,7 @@
  */
 import React, { FC, useEffect, useState } from 'react';
 
-import { Container, Text } from '@zextras/carbonio-design-system';
+import { Row, Text } from '@zextras/carbonio-design-system';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
@@ -13,21 +13,18 @@ import { useIsWritingLabel } from '../../../../hooks/useIsWritingLabel';
 import { getRoomNameSelector } from '../../../../store/selectors/RoomsSelectors';
 import useStore from '../../../../store/Store';
 
-const IsWritingLabelText = styled(Text)<{
-	$isWritingIsVisible: boolean;
-}>`
-	opacity: 0;
-	transition: opacity 0.3s ease;
-	${({ $isWritingIsVisible }): string | false => $isWritingIsVisible && 'opacity: 1;'}
-`;
+const ChatLabelText = styled(Text)<{ $showEffect: boolean }>`
+	@keyframes fadeEffect {
+		0% {
+			opacity: 0.2;
+		}
+		100% {
+			opacity: 1;
+		}
+	}
 
-const ChatLabelText = styled(Text)<{
-	$isWritingIsVisible: boolean;
-}>`
-	position: absolute;
-	opacity: 1;
-	transition: opacity 0.3s ease;
-	${({ $isWritingIsVisible }): string | false => $isWritingIsVisible && 'opacity: 0;'}
+	${({ $showEffect }): string =>
+		$showEffect ? `animation: fadeEffect 0.4s ease-in;` : `animation: none;`}
 `;
 
 type MeetingChatAccordionTitleProps = {
@@ -41,37 +38,27 @@ const MeetingChatAccordionTitle: FC<MeetingChatAccordionTitleProps> = ({ roomId 
 	const roomName = useStore((store) => getRoomNameSelector(store, roomId));
 
 	const isWritingLabel = useIsWritingLabel(roomId, true);
-
-	const [isWritingIsDefined, setIsWritingIsDefined] = useState(false);
-	const [writingLabel, setWritingLabel] = useState('');
+	const [writingLabel, setWritingLabel] = useState<false | string>(false);
+	const [showEffect, setShowEffect] = useState(false);
 
 	useEffect(() => {
-		if (isWritingLabel === undefined) {
-			setIsWritingIsDefined(false);
-			setTimeout(() => setWritingLabel(''), 400);
-		} else {
-			setIsWritingIsDefined(true);
+		setShowEffect(true);
+		setTimeout(() => {
+			setShowEffect(false);
+		}, 400);
+		if (isWritingLabel) {
 			setWritingLabel(isWritingLabel);
+		} else {
+			setWritingLabel(false);
 		}
 	}, [isWritingLabel]);
 
 	return (
-		<Container width="70%" height="fit" crossAlignment="flex-start">
-			<ChatLabelText
-				overflow="ellipsis"
-				$isWritingIsVisible={isWritingIsDefined}
-				data-testid="chat_title"
-			>
-				{`${chatLabel} - ${roomName}`}
+		<Row takeAvailableSpace mainAlignment="flex-start">
+			<ChatLabelText overflow="ellipsis" $showEffect={showEffect}>
+				{!writingLabel ? `${chatLabel} - ${roomName}` : writingLabel}
 			</ChatLabelText>
-			<IsWritingLabelText
-				overflow="ellipsis"
-				$isWritingIsVisible={isWritingIsDefined}
-				data-testid="is_writing_title"
-			>
-				{writingLabel}
-			</IsWritingLabelText>
-		</Container>
+		</Row>
 	);
 };
 

--- a/src/meetings/components/sidebar/MeetingConversationAccordion/MeetingConversationAccordion.test.tsx
+++ b/src/meetings/components/sidebar/MeetingConversationAccordion/MeetingConversationAccordion.test.tsx
@@ -127,25 +127,22 @@ describe('Meeting sidebar', () => {
 
 	test('title of the accordion changes when a user is writing', async () => {
 		const { store } = setupBasicGroup();
-
-		const chatTitle = screen.getByTestId('chat_title');
-		expect(chatTitle).toBeVisible();
+		expect(screen.getByText(`Chat - ${groupRoom.name}`)).toBeInTheDocument();
 
 		act(() => {
 			store.setIsWriting(groupRoom.id, mockUser2.id, true);
 		});
 
-		const isWritingText = await screen.findByTestId('is_writing_title');
-		expect(isWritingText).toBeVisible();
-		expect(chatTitle).not.toBeVisible();
+		expect(await screen.findByText(/User is typing.../i)).toBeInTheDocument();
+		expect(screen.queryByText(`Chat - ${groupRoom.name}`)).not.toBeInTheDocument();
 
 		act(() => {
 			store.setIsWriting(groupRoom.id, mockUser2.id, false);
 			jest.advanceTimersByTime(4000);
 		});
 
-		expect(isWritingText).not.toBeVisible();
-		expect(chatTitle).toBeVisible();
+		expect(screen.queryByText(/User is typing.../i)).not.toBeInTheDocument();
+		expect(await screen.findByText(`Chat - ${groupRoom.name}`)).toBeInTheDocument();
 	});
 	test('title of the accordion when two or more users are typing', async () => {
 		const { store } = setupBasicGroup();
@@ -155,8 +152,7 @@ describe('Meeting sidebar', () => {
 			store.setIsWriting(groupRoom.id, mockUser3.id, true);
 		});
 
-		const isWritingText = await screen.findByText(/2 people are typing.../i);
-		expect(isWritingText).toBeVisible();
+		expect(await screen.findByText(/2 people are typing.../i)).toBeInTheDocument();
 
 		act(() => {
 			store.setIsWriting(groupRoom.id, mockUser2.id, false);
@@ -164,6 +160,6 @@ describe('Meeting sidebar', () => {
 			jest.advanceTimersByTime(4000);
 		});
 
-		expect(isWritingText).not.toBeVisible();
+		expect(screen.queryByText(/2 people are typing.../i)).not.toBeInTheDocument();
 	});
 });

--- a/src/meetings/components/sidebar/MeetingConversationAccordion/MeetingConversationAccordion.tsx
+++ b/src/meetings/components/sidebar/MeetingConversationAccordion/MeetingConversationAccordion.tsx
@@ -172,7 +172,7 @@ const MeetingConversationAccordion: FC<MeetingConversationAccordionProps> = ({
 				padding={{ vertical: 'extrasmall', left: 'large', right: 'medium' }}
 			>
 				<MeetingChatAccordionTitle roomId={roomId} />
-				<Container height="fit" width="30%" orientation="horizontal" mainAlignment="flex-end">
+				<Row>
 					{expandButtonShouldAppear && (
 						<Tooltip label={!chatFullExpanded ? extendChatLabel : minimizeChatLabel}>
 							<CustomMediumButton
@@ -196,7 +196,7 @@ const MeetingConversationAccordion: FC<MeetingConversationAccordionProps> = ({
 							/>
 						</Tooltip>
 					)}
-				</Container>
+				</Row>
 			</Container>
 			{isChatOpenOrFullExpanded && (
 				<WrapperMeetingChat


### PR DESCRIPTION
To properly use the DS `Row` component, I had to change the logic for the transition between the chat title and the _isWriting_ label, removing the `position: absolute` css property.