### PR TITLE
fix: use carbonioFeatureWscEnabled as attribute to activate wsc ref: WSC-1866

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
 		"name": "carbonio-ws-collaboration-ui",
 		"display": "Chats",
 		"priority": 404,
-		"attrKey": "carbonioFeatureChatsEnabled",
+		"attrKey": "carbonioFeatureWscEnabled",
 		"type": "carbonio",
 		"translations_repository": "git@github.com:Zextras/carbonio-ws-collaboration-ui-i18n.git"
 	},

--- a/src/network/soap/SearchUsersByFeatureRequest.ts
+++ b/src/network/soap/SearchUsersByFeatureRequest.ts
@@ -21,7 +21,7 @@ export const searchUsersByFeatureRequest = (
 	soapFetch<SearchUsersByFeatureRequest, SearchUsersByFeatureResponse>('SearchUsersByFeature', {
 		_jsns: 'urn:zimbraAccount',
 		name: text,
-		feature: 'CHATS'
+		feature: 'WSC'
 	}).then((response: SearchUsersByFeatureResponse) => {
 		if (response.Fault?.Detail?.Error?.Code === 'service.UNKNOWN_DOCUMENT') {
 			return autoCompleteGalRequest(text);

--- a/src/types/network/soap/searchUsersByFeatureRequest.ts
+++ b/src/types/network/soap/searchUsersByFeatureRequest.ts
@@ -7,7 +7,7 @@
 export type SearchUsersByFeatureRequest = {
 	_jsns: 'urn:zimbraAccount';
 	name: string;
-	feature: 'CHATS';
+	feature: 'WSC';
 };
 
 export type SearchUsersByFeatureResponse = {


### PR DESCRIPTION
Changed LDAP attribute to activate/disactivate Workstream Collaboratio app:
- Used `carbonioFeatureWscEnabled` (already present) instead of `carbonioFeatureChatsEnabled` (it will be deprecated in 25.6)
- Changed `SearchUsersByUsersRequest` param to find users with  `carbonioFeatureWscEnabled` active