### PR TITLE
refactor: improve session store slice usage ref: WSC-1918

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -24,8 +24,8 @@ import { setDateDefault } from './utils/dateUtils';
 
 export default function App(): React.JSX.Element {
 	const setLoginInfo = useStore((state) => state.setLoginInfo);
-	const setChatsBeStatus = useStore((state) => state.setChatsBeStatus);
 	const setAttributes = useStore((state) => state.setAttributes);
+	const setChatsBeStatus = useStore((state) => state.setChatsBeStatus);
 
 	const authenticated = useAuthenticated();
 	const { prefs, attrs } = useUserSettings();

--- a/src/chats/components/conversation/Conversation.test.tsx
+++ b/src/chats/components/conversation/Conversation.test.tsx
@@ -128,7 +128,7 @@ describe('Conversation view', () => {
 		const store = useStore.getState();
 		store.addRoom(testRoom);
 		setup(<Conversation roomId={testRoom.id} />);
-		const ConversationWrapper = screen.getByTestId('ConversationWrapper');
+		const ConversationWrapper = screen.getByTestId(`ConversationWrapper-${testRoom.id}`);
 		expect(ConversationWrapper).toHaveStyle(`background-image: url('papyrus.png')`);
 	});
 
@@ -137,7 +137,7 @@ describe('Conversation view', () => {
 		const store = useStore.getState();
 		store.addRoom(testRoom);
 		setup(<Conversation roomId={testRoom.id} />);
-		const ConversationWrapper = screen.getByTestId('ConversationWrapper');
+		const ConversationWrapper = screen.getByTestId(`ConversationWrapper-${testRoom.id}`);
 		expect(ConversationWrapper).toHaveStyle(`background-image: url('papyrus-dark.png')`);
 	});
 

--- a/src/chats/components/conversation/Conversation.tsx
+++ b/src/chats/components/conversation/Conversation.tsx
@@ -36,7 +36,7 @@ const Conversation = ({ roomId }: ConversationProps): ReactElement => {
 
 	return (
 		<ConversationWrapper
-			data-testid="ConversationWrapper"
+			data-testid={`ConversationWrapper-${roomId}`}
 			mainAlignment="flex-start"
 			orientation="horizontal"
 			$darkModeActive={darkReaderStatus}

--- a/src/chats/components/conversation/messageBubbles/bubbleActions/useBubbleContextualMenuDropDown.test.tsx
+++ b/src/chats/components/conversation/messageBubbles/bubbleActions/useBubbleContextualMenuDropDown.test.tsx
@@ -98,7 +98,6 @@ const messageTypes: Array<[string, TextMessage]> = [
 
 beforeEach(() => {
 	const store: RootStore = useStore.getState();
-	store.setSessionId(mySessionId);
 	store.addRoom(mockedRoom);
 	store.setAttributes(createMockAttributesList());
 });

--- a/src/chats/components/secondaryBar/ConversationsFilter.tsx
+++ b/src/chats/components/secondaryBar/ConversationsFilter.tsx
@@ -19,9 +19,6 @@ import { Container, Input, Tooltip, Button } from '@zextras/carbonio-design-syst
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
-import { getSidebarFilterHasFocus } from '../../../store/selectors/SessionSelectors';
-import useStore from '../../../store/Store';
-
 const FilterContainer = styled(Container)`
 	height: fit-content;
 	position: sticky;
@@ -48,8 +45,7 @@ const ConversationsFilter: FC<ConversationsFilterProps> = ({ expanded, setFilter
 	const filterTooltip = t('conversationFilter.filterTooltip', 'Filter list');
 	const closeTooltip = t('conversationFilter.closeTooltip', 'Close filter');
 
-	const filterHasFocus = useStore((store) => getSidebarFilterHasFocus(store));
-	const setFilterHasFocus = useStore((store) => store.setFilterHasFocus);
+	const [filterHasFocus, setFilterHasFocus] = useState(false);
 
 	const [searchInput, setSearchInput] = useState('');
 
@@ -111,7 +107,6 @@ const ConversationsFilter: FC<ConversationsFilterProps> = ({ expanded, setFilter
 						data-testid="filter_input"
 						inputRef={filterInputRef}
 						height="2.938rem"
-						backgroundColor="gray5"
 						borderColor="gray3"
 						label={filterLabel}
 						value={searchInput}
@@ -128,7 +123,7 @@ const ConversationsFilter: FC<ConversationsFilterProps> = ({ expanded, setFilter
 							icon="FunnelOutline"
 							size="large"
 							onClick={handleInputFocus}
-							color="gray5"
+							color="text"
 						/>
 					</Tooltip>
 				</CustomFunnelContainer>

--- a/src/chats/views/RoomView.test.tsx
+++ b/src/chats/views/RoomView.test.tsx
@@ -34,6 +34,13 @@ describe('RoomView', () => {
 		expect(screen.queryByTestId('ConversationWrapper-roomId')).not.toBeInTheDocument();
 	});
 
+	test('roomId param is not setted', () => {
+		const spyUseParams = jest.spyOn(ReactRouter, 'useParams');
+		spyUseParams.mockReturnValue({ roomId: undefined });
+		setup(<RoomView />);
+		expect(screen.queryByTestId('ConversationWrapper-roomId')).not.toBeInTheDocument();
+	});
+
 	test('roomId param is set as selectedRoomId', () => {
 		const spyUseParams = jest.spyOn(ReactRouter, 'useParams');
 		spyUseParams.mockReturnValue({ roomId: room.id });

--- a/src/chats/views/RoomView.test.tsx
+++ b/src/chats/views/RoomView.test.tsx
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+import * as ReactRouter from 'react-router';
+
+import RoomView from './RoomView';
+import useStore from '../../store/Store';
+import { createMockRoom } from '../../tests/createMock';
+import { setup } from '../../tests/test-utils';
+
+const room = createMockRoom({ id: 'test-room-1' });
+
+beforeEach(() => {
+	useStore.getState().addRoom(createMockRoom(room));
+});
+describe('RoomView', () => {
+	test('roomId param correspond to a room stored in the store', () => {
+		const spyUseParams = jest.spyOn(ReactRouter, 'useParams');
+		spyUseParams.mockReturnValue({ roomId: room.id });
+		setup(<RoomView />);
+		expect(screen.getByTestId(`ConversationWrapper-${room.id}`)).toBeInTheDocument();
+	});
+
+	test('roomId param does not correspond to any stored room', () => {
+		const spyUseParams = jest.spyOn(ReactRouter, 'useParams');
+		spyUseParams.mockReturnValue({ roomId: 'roomId' });
+		setup(<RoomView />);
+		expect(screen.queryByTestId('ConversationWrapper-roomId')).not.toBeInTheDocument();
+	});
+
+	test('roomId param is set as selectedRoomId', () => {
+		const spyUseParams = jest.spyOn(ReactRouter, 'useParams');
+		spyUseParams.mockReturnValue({ roomId: room.id });
+		setup(<RoomView />);
+		expect(useStore.getState().session.selectedRoom).toBe(room.id);
+	});
+});

--- a/src/chats/views/RoomView.tsx
+++ b/src/chats/views/RoomView.tsx
@@ -24,13 +24,13 @@ const RoomView = (): ReactElement => {
 		[params]
 	);
 
-	const setSelectedRoomOneToOneGroup = useStore((state) => state.setSelectedRoomOneToOneGroup);
+	const setSelectedRoom = useStore((state) => state.setSelectedRoom);
 	const roomType = useStore((store) => getRoomTypeSelector(store, selectedRoomId));
 
-	// Keep selectedRoomOneToOneGroup update
+	// Keep selectedRoom update
 	useEffect(() => {
-		setSelectedRoomOneToOneGroup(selectedRoomId);
-	}, [selectedRoomId, setSelectedRoomOneToOneGroup]);
+		setSelectedRoom(selectedRoomId);
+	}, [selectedRoomId, setSelectedRoom]);
 
 	if (!roomType) {
 		return (

--- a/src/chats/views/RoomView.tsx
+++ b/src/chats/views/RoomView.tsx
@@ -15,13 +15,12 @@ import { getRoomTypeSelector } from '../../store/selectors/RoomsSelectors';
 import useStore from '../../store/Store';
 import Conversation from '../components/conversation/Conversation';
 
-// Render TestRoom ONLY when we are sure room is present in the store
 const RoomView = (): ReactElement => {
 	// Retrieve room id from url
-	const params: { roomId?: string } = useParams();
+	const { roomId } = useParams();
 	const selectedRoomId: string = useMemo(
-		() => (params?.roomId ? decodeURIComponent(params.roomId) : ''),
-		[params]
+		() => (roomId ? decodeURIComponent(roomId) : ''),
+		[roomId]
 	);
 
 	const setSelectedRoom = useStore((state) => state.setSelectedRoom);

--- a/src/network/apis/MeetingsApi.test.ts
+++ b/src/network/apis/MeetingsApi.test.ts
@@ -49,7 +49,7 @@ const sdpOffer = 'spdOfferMock';
 beforeEach(() => {
 	const store: RootStore = useStore.getState();
 	store.setLoginInfo(userId, 'User');
-	store.setSessionId('queueId');
+	store.setQueueId('queueId');
 	store.addRoom(roomMock);
 });
 
@@ -401,7 +401,7 @@ describe('Meetings API', () => {
 	test('leaveWaitingRoom is called correctly for guest user', async () => {
 		document.cookie = `ZM_AUTH_TOKEN=123456789`;
 		useStore.getState().setLoginInfo(userId, guestUser.email, guestUser.name, guestUser.type);
-		useStore.getState().setSessionId('queueId');
+		useStore.getState().setQueueId('queueId');
 		await meetingsApi.leaveWaitingRoom(meetingMock.id);
 
 		expect(spyOnFetch).toHaveBeenCalledWith(

--- a/src/network/websocket/WebSocketClient.test.ts
+++ b/src/network/websocket/WebSocketClient.test.ts
@@ -73,7 +73,7 @@ describe('WebSocketClient', () => {
 		wsClient.connect();
 		const message = { type: WsEventType.INITIALIZATION, queueId: 'queueId' };
 		wsClient._onMessage({ data: JSON.stringify(message) } as MessageEvent);
-		expect(useStore.getState().session.sessionId).toBe('queueId');
+		expect(useStore.getState().session.queueId).toBe('queueId');
 	});
 
 	test('retryReconnection is called with exponential backoff', () => {

--- a/src/network/websocket/wsEventsHandler.ts
+++ b/src/network/websocket/wsEventsHandler.ts
@@ -17,7 +17,7 @@ export function wsEventsHandler(event: WsEvent): void {
 	switch (getEventArea(event.type)) {
 		case EventArea.GENERAL: {
 			if (event.type === WsEventType.INITIALIZATION) {
-				state.setSessionId(event.queueId);
+				state.setQueueId(event.queueId);
 			}
 			break;
 		}

--- a/src/network/xmpp/handlers/historyMessageHandler.ts
+++ b/src/network/xmpp/handlers/historyMessageHandler.ts
@@ -178,6 +178,10 @@ export function onLoadFullHistory(stanza: Element): void {
 
 	if (chatExporting?.roomId === roomId) {
 		const isHistoryComplete = getRequiredTagElement(stanza, 'fin').getAttribute('complete');
-		chatExporting.exporter.handleFullHistoryResponse(!!isHistoryComplete);
+		if (isHistoryComplete) {
+			chatExporting.exporter.exportHistory();
+		} else {
+			chatExporting.exporter.continueExporting();
+		}
 	}
 }

--- a/src/network/xmpp/utility/displayMessageBrowserNotification.test.ts
+++ b/src/network/xmpp/utility/displayMessageBrowserNotification.test.ts
@@ -15,7 +15,7 @@ import {
 } from '../../../tests/createMock';
 
 const room = createMockRoom();
-const loggedUser = createMockUser({ id: 'loggeduserId', name: 'Logged User' });
+const loggedUser = createMockUser({ id: 'loggedUserId', name: 'Logged User' });
 const user = createMockUser({ id: 'userId', name: 'User' });
 
 beforeEach(() => {
@@ -40,7 +40,7 @@ describe('Test display message browser notification', () => {
 
 	test('Avoid sending desktop notification on conversation with focused input', async () => {
 		const store = useStore.getState();
-		store.setSelectedRoomOneToOneGroup(room.id);
+		store.setSelectedRoom(room.id);
 		store.setInputHasFocus(room.id, true);
 
 		const newMessage = createMockTextMessage({ roomId: room.id, from: user.id });

--- a/src/network/xmpp/utility/displayMessageBrowserNotification.ts
+++ b/src/network/xmpp/utility/displayMessageBrowserNotification.ts
@@ -21,8 +21,7 @@ export const displayChatNotification = (roomId: string): boolean => {
 	const isMeetingTab = !isEmpty(store.activeMeeting);
 	const isOneToOneGroupMessage = includes([RoomType.ONE_TO_ONE, RoomType.GROUP], room?.type);
 	const inputIsFocused =
-		store.session.selectedRoomOneToOneGroup === roomId &&
-		store.activeConversations[roomId].inputHasFocus;
+		store.session.selectedRoom === roomId && store.activeConversations[roomId].inputHasFocus;
 	const chatsNotificationsSettingsEnabled = getLocalStorageItem(
 		LOCAL_STORAGE_NAMES.NOTIFICATIONS
 	)?.DesktopNotifications;

--- a/src/settings/components/chatExporter/ChatExporter.test.tsx
+++ b/src/settings/components/chatExporter/ChatExporter.test.tsx
@@ -5,22 +5,18 @@
  */
 import ChatExporter from './ChatExporter';
 import useStore from '../../../store/Store';
-import { createMockMember, createMockRoom, createMockTextMessage } from '../../../tests/createMock';
-import { RoomBe, RoomType } from '../../../types/network/models/roomBeTypes';
+import { createMockRoom, createMockTextMessage } from '../../../tests/createMock';
+import { RoomType } from '../../../types/network/models/roomBeTypes';
 
 const roomId = 'roomId';
-const groupRoom: RoomBe = createMockRoom({
+
+const groupRoom = createMockRoom({
 	id: roomId,
-	name: '',
-	description: 'A description',
-	type: RoomType.GROUP,
-	members: [createMockMember({ userId: 'myId' })],
-	userSettings: { muted: false }
+	type: RoomType.GROUP
 });
 
 beforeEach(() => {
-	const store = useStore.getState();
-	store.addRoom(groupRoom);
+	useStore.getState().addRoom(groupRoom);
 });
 
 describe('ChatExporter tests', () => {
@@ -43,7 +39,7 @@ describe('ChatExporter tests', () => {
 		const message = createMockTextMessage({ date: Date.now() });
 
 		chatExporter.addMessageToFullHistory(message);
-		chatExporter.handleFullHistoryResponse(false);
+		chatExporter.continueExporting();
 
 		expect(spyOnRequestFullHistory).toHaveBeenCalledWith(roomId, message.date);
 	});
@@ -63,7 +59,7 @@ describe('ChatExporter tests', () => {
 		document.body.removeChild = jest.fn();
 		URL.createObjectURL = jest.fn().mockReturnValue('blob:url');
 
-		chatExporter.handleFullHistoryResponse(true);
+		chatExporter.exportHistory();
 
 		expect(document.body.appendChild).toHaveBeenCalled();
 		expect(document.body.removeChild).toHaveBeenCalled();

--- a/src/settings/components/chatExporter/ChatExporter.ts
+++ b/src/settings/components/chatExporter/ChatExporter.ts
@@ -47,7 +47,7 @@ class ChatExporter implements IChatExporter {
 				content += this.messageFormatter(message);
 			}
 		});
-		useStore.getState().setChatExporting(this.roomId, ExportStatus.DOWNLOADING);
+		useStore.getState().setChatExportStatus(ExportStatus.DOWNLOADING);
 
 		// Create and download the file
 		const blob = new Blob([content], { type: 'text/plain' });

--- a/src/settings/components/chatExporter/ChatExporter.ts
+++ b/src/settings/components/chatExporter/ChatExporter.ts
@@ -15,15 +15,16 @@ import { formatDate } from '../../../utils/dateUtils';
 
 export interface IChatExporter {
 	addMessageToFullHistory(message: Message): void;
-	handleFullHistoryResponse(isHistoryComplete: boolean): void;
+	continueExporting(): void;
+	exportHistory(): void;
 }
 
 class ChatExporter implements IChatExporter {
-	private roomId: string;
+	readonly roomId: string;
 
-	private fullHistory: Message[] = [];
+	readonly fullHistory: Message[] = [];
 
-	private xmppClient: IXMPPClient = useStore.getState().connections.xmppClient;
+	readonly xmppClient: IXMPPClient = useStore.getState().connections.xmppClient;
 
 	constructor(roomId: string) {
 		this.roomId = roomId;
@@ -34,23 +35,19 @@ class ChatExporter implements IChatExporter {
 		this.fullHistory.push(message);
 	}
 
-	public handleFullHistoryResponse(isHistoryComplete: boolean): void {
-		if (isHistoryComplete) {
-			this.exportHistory();
-		} else {
-			const from = last(this.fullHistory)?.date ?? 0;
-			this.xmppClient.requestFullHistory(this.roomId, from);
-		}
+	public continueExporting(): void {
+		const from = last(this.fullHistory)?.date ?? 0;
+		this.xmppClient.requestFullHistory(this.roomId, from);
 	}
 
-	private exportHistory(): void {
+	public exportHistory(): void {
 		let content = '';
 		forEach(this.fullHistory, (message) => {
 			if (message.type === MessageType.TEXT_MSG) {
 				content += this.messageFormatter(message);
 			}
 		});
-		useStore.getState().setChatExportStatus(ExportStatus.DOWNLOADING);
+		useStore.getState().setChatExporting(this.roomId, ExportStatus.DOWNLOADING);
 
 		// Create and download the file
 		const blob = new Blob([content], { type: 'text/plain' });

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -23,10 +23,10 @@ import { RootStore } from '../types/store/StoreTypes';
 const useStore = create<RootStore>()(
 	devtools(
 		(set, get, api): RootStore => ({
+			...useSessionStoreSlice(set, get, api),
 			...useUsersStoreSlice(set, get, api),
 			...useRoomsStoreSlice(set, get, api),
 			...useMessagesStoreSlice(set, get, api),
-			...useSessionStoreSlice(set, get, api),
 			...useMarkersStoreSlice(set, get, api),
 			...useActiveConversationsSlice(set, get, api),
 			...useConnectionsStoreSlice(set, get, api),

--- a/src/store/selectors/SessionSelectors.ts
+++ b/src/store/selectors/SessionSelectors.ts
@@ -11,8 +11,6 @@ import { UserType } from '../../types/store/UserTypes';
 export const getSelectedConversation = (store: RootStore, roomId: string): boolean =>
 	store.session.selectedRoomOneToOneGroup === roomId;
 
-export const getSidebarFilterHasFocus = (store: RootStore): boolean => store.session.filterHasFocus;
-
 export const getAttribute = (
 	store: RootStore,
 	attributeName: keyof AttributesList

--- a/src/store/selectors/SessionSelectors.ts
+++ b/src/store/selectors/SessionSelectors.ts
@@ -9,7 +9,7 @@ import { RootStore } from '../../types/store/StoreTypes';
 import { UserType } from '../../types/store/UserTypes';
 
 export const getSelectedConversation = (store: RootStore, roomId: string): boolean =>
-	store.session.selectedRoomOneToOneGroup === roomId;
+	store.session.selectedRoom === roomId;
 
 export const getAttribute = (
 	store: RootStore,

--- a/src/store/slices/SessionStoreSlice.test.ts
+++ b/src/store/slices/SessionStoreSlice.test.ts
@@ -22,11 +22,8 @@ const groupRoom: RoomBe = createMockRoom({
 
 describe('SessionStoreSlice tests', () => {
 	test('loginInfo', () => {
-		const { result } = renderHook(() => useStore());
-		act(() => {
-			result.current.setLoginInfo('id', 'name', 'displayName');
-		});
-		expect(result.current.session).toStrictEqual({
+		useStore.getState().setLoginInfo('id', 'name', 'displayName');
+		expect(useStore.getState().session).toStrictEqual({
 			id: 'id',
 			name: 'name',
 			displayName: 'displayName',
@@ -38,6 +35,75 @@ describe('SessionStoreSlice tests', () => {
 		const testQueueId = 'test-queueId';
 		useStore.getState().setQueueId(testQueueId);
 		expect(useStore.getState().session.queueId).toBe(testQueueId);
+	});
+
+	describe('attributes', () => {
+		test('Set boolean attributes to true', () => {
+			useStore.getState().setAttributes({
+				carbonioWscPrivateChatCreation: 'TRUE',
+				carbonioWscAttachmentUpload: 'TRUE',
+				carbonioWscShowMessageReads: 'TRUE',
+				carbonioWscShowUsersPresence: 'TRUE',
+				carbonioWscVideoCallEnabled: 'TRUE',
+				carbonioWscRecordingEnabled: 'TRUE',
+				carbonioWscVirtualBackgroundEnabled: 'TRUE'
+			});
+
+			const { attributes } = useStore.getState().session;
+			expect(attributes?.privateChatCreation).toBe(true);
+			expect(attributes?.attachmentUpload).toBe(true);
+			expect(attributes?.showMessageReads).toBe(true);
+			expect(attributes?.showUsersPresence).toBe(true);
+			expect(attributes?.videoCallEnabled).toBe(true);
+			expect(attributes?.recordingEnabled).toBe(true);
+			expect(attributes?.virtualBackgroundEnabled).toBe(true);
+		});
+
+		test('Set boolean attributes to false', () => {
+			useStore.getState().setAttributes({
+				carbonioWscPrivateChatCreation: 'FALSE',
+				carbonioWscAttachmentUpload: 'FALSE',
+				carbonioWscShowMessageReads: 'FALSE',
+				carbonioWscShowUsersPresence: 'FALSE',
+				carbonioWscVideoCallEnabled: 'FALSE',
+				carbonioWscRecordingEnabled: 'FALSE',
+				carbonioWscVirtualBackgroundEnabled: 'FALSE'
+			});
+
+			const { attributes } = useStore.getState().session;
+			expect(attributes?.privateChatCreation).toBe(false);
+			expect(attributes?.attachmentUpload).toBe(false);
+			expect(attributes?.showMessageReads).toBe(false);
+			expect(attributes?.showUsersPresence).toBe(false);
+			expect(attributes?.videoCallEnabled).toBe(false);
+			expect(attributes?.recordingEnabled).toBe(false);
+			expect(attributes?.virtualBackgroundEnabled).toBe(false);
+		});
+
+		test('Set number attributes', () => {
+			useStore.getState().setAttributes({
+				carbonioWscMaxGroupMembers: '32',
+				carbonioWscMaxAttachmentSize: '2',
+				carbonioWscMaxRoomPictureSize: '2',
+				carbonioWscMessageDeleteTimeLimit: '5m',
+				carbonioWscMessageEditTimeLimit: '5m'
+			});
+
+			const { attributes } = useStore.getState().session;
+			expect(attributes?.maxGroupMembers).toBe(32);
+			expect(attributes?.maxAttachmentSize).toBe(2);
+			expect(attributes?.maxRoomPictureSize).toBe(2);
+			expect(attributes?.messageDeleteTimeLimit).toBe(5);
+			expect(attributes?.messageEditTimeLimit).toBe(5);
+		});
+
+		test('groupChatCreation is set to false is maxGroupMembers is <= 2', () => {
+			useStore.getState().setAttributes({
+				carbonioWscGroupChatCreation: 'TRUE',
+				carbonioWscMaxGroupMembers: '2'
+			});
+			expect(useStore.getState().session.attributes?.groupChatCreation).toBe(false);
+		});
 	});
 
 	describe('selectedRoom', () => {

--- a/src/store/slices/SessionStoreSlice.test.ts
+++ b/src/store/slices/SessionStoreSlice.test.ts
@@ -43,8 +43,7 @@ describe('SessionStoreSlice tests', () => {
 				chats_be: undefined,
 				xmpp: undefined,
 				websocket: undefined
-			},
-			filterHasFocus: false
+			}
 		});
 	});
 

--- a/src/store/slices/SessionStoreSlice.test.ts
+++ b/src/store/slices/SessionStoreSlice.test.ts
@@ -7,29 +7,21 @@
 import { act, renderHook } from '@testing-library/react';
 
 import ChatExporter from '../../settings/components/chatExporter/ChatExporter';
-import { createMockMember, createMockRoom } from '../../tests/createMock';
+import { createMockRoom } from '../../tests/createMock';
 import { RoomBe, RoomType } from '../../types/network/models/roomBeTypes';
 import { ExportStatus } from '../../types/store/SessionTypes';
 import { UserType } from '../../types/store/UserTypes';
 import useStore from '../Store';
 
 const roomId = 'roomId';
+
 const groupRoom: RoomBe = createMockRoom({
 	id: roomId,
-	name: '',
-	description: 'A description',
-	type: RoomType.GROUP,
-	members: [createMockMember({ userId: 'myId' })],
-	userSettings: { muted: false }
-});
-
-beforeEach(() => {
-	const store = useStore.getState();
-	store.addRoom(groupRoom);
+	type: RoomType.GROUP
 });
 
 describe('SessionStoreSlice tests', () => {
-	test('Set login info', () => {
+	test('loginInfo', () => {
 		const { result } = renderHook(() => useStore());
 		act(() => {
 			result.current.setLoginInfo('id', 'name', 'displayName');
@@ -42,33 +34,41 @@ describe('SessionStoreSlice tests', () => {
 		});
 	});
 
-	test('Set queueId', () => {
+	test('queueId', () => {
 		const testQueueId = 'test-queueId';
 		useStore.getState().setQueueId(testQueueId);
 		expect(useStore.getState().session.queueId).toBe(testQueueId);
 	});
 
-	test('Set initial selected room', () => {
-		useStore.getState().setSelectedRoom(roomId);
-		expect(useStore.getState().session.selectedRoom).toBe(roomId);
-	});
-
-	test('Remove selected room', () => {
-		useStore.setState({ session: { selectedRoom: roomId } });
-		useStore.getState().setSelectedRoom(undefined);
-		expect(useStore.getState().session.selectedRoom).toBeUndefined();
-	});
-
-	test('Replace selected room', () => {
-		const { result } = renderHook(() => useStore());
-		act(() => {
-			result.current.setSelectedRoom('oldRoomId');
-			result.current.setSelectedRoom(roomId);
+	describe('selectedRoom', () => {
+		test('Set initial selected room', () => {
+			useStore.getState().setSelectedRoom(roomId);
+			expect(useStore.getState().session.selectedRoom).toBe(roomId);
 		});
-		expect(result.current.session.selectedRoom).toBe('roomId');
+
+		test('Change selected room', () => {
+			useStore.setState({ session: { selectedRoom: 'selectedRoom1' } });
+			useStore.getState().setSelectedRoom('selectedRoom2');
+			expect(useStore.getState().session.selectedRoom).toBe('selectedRoom2');
+		});
+
+		test('Remove selected room', () => {
+			useStore.setState({ session: { selectedRoom: roomId } });
+			useStore.getState().setSelectedRoom(undefined);
+			expect(useStore.getState().session.selectedRoom).toBeUndefined();
+		});
 	});
 
-	describe('Export chat', () => {
+	test('customLogo', () => {
+		const logo = 'customLogo';
+		useStore.getState().setCustomLogo(logo);
+		expect(useStore.getState().session.customLogo).toBe(logo);
+	});
+
+	beforeEach(() => {
+		useStore.getState().addRoom(groupRoom);
+	});
+	describe('chatExporting', () => {
 		test('Start chat export', () => {
 			const { result } = renderHook(() => useStore());
 			act(() => {
@@ -90,11 +90,11 @@ describe('SessionStoreSlice tests', () => {
 			expect(result.current.session.chatExporting).toBeUndefined();
 		});
 
-		test('Set chat export status', () => {
+		test('Change chat export status', () => {
 			const { result } = renderHook(() => useStore());
 			act(() => {
 				result.current.setChatExporting(roomId);
-				result.current.setChatExportStatus(ExportStatus.DOWNLOADING);
+				result.current.setChatExporting(roomId, ExportStatus.DOWNLOADING);
 			});
 			expect(result.current.session.chatExporting).toStrictEqual({
 				roomId,

--- a/src/store/slices/SessionStoreSlice.test.ts
+++ b/src/store/slices/SessionStoreSlice.test.ts
@@ -49,20 +49,23 @@ describe('SessionStoreSlice tests', () => {
 	});
 
 	test('Set initial selected room', () => {
-		const { result } = renderHook(() => useStore());
-		act(() => {
-			result.current.setSelectedRoomOneToOneGroup(roomId);
-		});
-		expect(result.current.session.selectedRoomOneToOneGroup).toBe(roomId);
+		useStore.getState().setSelectedRoom(roomId);
+		expect(useStore.getState().session.selectedRoom).toBe(roomId);
+	});
+
+	test('Remove selected room', () => {
+		useStore.setState({ session: { selectedRoom: roomId } });
+		useStore.getState().setSelectedRoom(undefined);
+		expect(useStore.getState().session.selectedRoom).toBeUndefined();
 	});
 
 	test('Replace selected room', () => {
 		const { result } = renderHook(() => useStore());
 		act(() => {
-			result.current.setSelectedRoomOneToOneGroup('oldRoomId');
-			result.current.setSelectedRoomOneToOneGroup(roomId);
+			result.current.setSelectedRoom('oldRoomId');
+			result.current.setSelectedRoom(roomId);
 		});
-		expect(result.current.session.selectedRoomOneToOneGroup).toBe('roomId');
+		expect(result.current.session.selectedRoom).toBe('roomId');
 	});
 
 	describe('Export chat', () => {

--- a/src/store/slices/SessionStoreSlice.test.ts
+++ b/src/store/slices/SessionStoreSlice.test.ts
@@ -160,7 +160,7 @@ describe('SessionStoreSlice tests', () => {
 			const { result } = renderHook(() => useStore());
 			act(() => {
 				result.current.setChatExporting(roomId);
-				result.current.setChatExporting(roomId, ExportStatus.DOWNLOADING);
+				result.current.setChatExportStatus(ExportStatus.DOWNLOADING);
 			});
 			expect(result.current.session.chatExporting).toStrictEqual({
 				roomId,

--- a/src/store/slices/SessionStoreSlice.test.ts
+++ b/src/store/slices/SessionStoreSlice.test.ts
@@ -38,13 +38,14 @@ describe('SessionStoreSlice tests', () => {
 			id: 'id',
 			name: 'name',
 			displayName: 'displayName',
-			userType: UserType.INTERNAL,
-			connections: {
-				chats_be: undefined,
-				xmpp: undefined,
-				websocket: undefined
-			}
+			userType: UserType.INTERNAL
 		});
+	});
+
+	test('Set queueId', () => {
+		const testQueueId = 'test-queueId';
+		useStore.getState().setQueueId(testQueueId);
+		expect(useStore.getState().session.queueId).toBe(testQueueId);
 	});
 
 	test('Set initial selected room', () => {

--- a/src/store/slices/SessionStoreSlice.ts
+++ b/src/store/slices/SessionStoreSlice.ts
@@ -38,15 +38,6 @@ export const useSessionStoreSlice: StateCreator<
 			'SESSION/LOGIN_INFO'
 		);
 	},
-	setQueueId: (queueId: string): void => {
-		set(
-			produce((draft: RootStore) => {
-				draft.session.queueId = queueId;
-			}),
-			false,
-			'SESSION/QUEUE_ID'
-		);
-	},
 	setAttributes: (attrs: AccountSettingsAttrs): void => {
 		set(
 			produce((draft: RootStore) => {
@@ -77,15 +68,24 @@ export const useSessionStoreSlice: StateCreator<
 			'SESSION/SET_ATTRS'
 		);
 	},
-	setSelectedRoomOneToOneGroup: (roomId: string): void => {
+	setQueueId: (queueId: string): void => {
 		set(
 			produce((draft: RootStore) => {
-				if (draft.session.selectedRoomOneToOneGroup !== roomId) {
-					draft.session.selectedRoomOneToOneGroup = roomId;
+				draft.session.queueId = queueId;
+			}),
+			false,
+			'SESSION/QUEUE_ID'
+		);
+	},
+	setSelectedRoom: (roomId?: string): void => {
+		set(
+			produce((draft: RootStore) => {
+				if (draft.session.selectedRoom !== roomId) {
+					draft.session.selectedRoom = roomId;
 				}
 			}),
 			false,
-			'SESSION/SET_SELECTED_ROOM_ONE_TO_ONE_GROUP'
+			'SESSION/SET_SELECTED_ROOM'
 		);
 	},
 	setCustomLogo: (logo: string | false): void => {

--- a/src/store/slices/SessionStoreSlice.ts
+++ b/src/store/slices/SessionStoreSlice.ts
@@ -97,14 +97,14 @@ export const useSessionStoreSlice: StateCreator<
 			'SESSION/SET_CUSTOM_LOGO'
 		);
 	},
-	setChatExporting: (roomId?: string): void => {
+	setChatExporting: (roomId?: string, status = ExportStatus.EXPORTING): void => {
 		set(
 			produce((draft: RootStore) => {
 				if (roomId) {
 					draft.session.chatExporting = {
 						roomId,
-						exporter: new ChatExporter(roomId),
-						status: ExportStatus.EXPORTING
+						exporter: draft.session.chatExporting?.exporter || new ChatExporter(roomId),
+						status
 					};
 				} else {
 					delete draft.session.chatExporting;
@@ -112,17 +112,6 @@ export const useSessionStoreSlice: StateCreator<
 			}),
 			false,
 			'SESSION/SET_CHAT_EXPORTING'
-		);
-	},
-	setChatExportStatus: (status: ExportStatus): void => {
-		set(
-			produce((draft: RootStore) => {
-				if (draft.session.chatExporting) {
-					draft.session.chatExporting.status = status;
-				}
-			}),
-			false,
-			'SESSION/SET_CHAT_EXPORTING_STATUS'
 		);
 	}
 });

--- a/src/store/slices/SessionStoreSlice.ts
+++ b/src/store/slices/SessionStoreSlice.ts
@@ -97,14 +97,14 @@ export const useSessionStoreSlice: StateCreator<
 			'SESSION/SET_CUSTOM_LOGO'
 		);
 	},
-	setChatExporting: (roomId?: string, status = ExportStatus.EXPORTING): void => {
+	setChatExporting: (roomId?: string): void => {
 		set(
 			produce((draft: RootStore) => {
 				if (roomId) {
 					draft.session.chatExporting = {
 						roomId,
-						exporter: draft.session.chatExporting?.exporter || new ChatExporter(roomId),
-						status
+						exporter: new ChatExporter(roomId),
+						status: ExportStatus.EXPORTING
 					};
 				} else {
 					delete draft.session.chatExporting;
@@ -112,6 +112,17 @@ export const useSessionStoreSlice: StateCreator<
 			}),
 			false,
 			'SESSION/SET_CHAT_EXPORTING'
+		);
+	},
+	setChatExportStatus: (status: ExportStatus): void => {
+		set(
+			produce((draft: RootStore) => {
+				if (draft.session.chatExporting) {
+					draft.session.chatExporting.status = status;
+				}
+			}),
+			false,
+			'SESSION/SET_CHAT_EXPORTING_STATUS'
 		);
 	}
 });

--- a/src/store/slices/SessionStoreSlice.ts
+++ b/src/store/slices/SessionStoreSlice.ts
@@ -30,12 +30,7 @@ export const useSessionStoreSlice: StateCreator<
 					id,
 					name,
 					displayName,
-					userType: userType ?? UserType.INTERNAL,
-					connections: {
-						chats_be: undefined,
-						xmpp: undefined,
-						websocket: undefined
-					}
+					userType: userType ?? UserType.INTERNAL
 				};
 				UserDataRetriever.getDebouncedUser(id, true);
 			}),
@@ -43,13 +38,13 @@ export const useSessionStoreSlice: StateCreator<
 			'SESSION/LOGIN_INFO'
 		);
 	},
-	setSessionId: (sessionId: string): void => {
+	setQueueId: (queueId: string): void => {
 		set(
 			produce((draft: RootStore) => {
-				draft.session.sessionId = sessionId;
+				draft.session.queueId = queueId;
 			}),
 			false,
-			'SESSION/SESSION_ID'
+			'SESSION/QUEUE_ID'
 		);
 	},
 	setAttributes: (attrs: AccountSettingsAttrs): void => {

--- a/src/store/slices/SessionStoreSlice.ts
+++ b/src/store/slices/SessionStoreSlice.ts
@@ -10,8 +10,8 @@ import { produce } from 'immer';
 import { StateCreator } from 'zustand';
 
 import ChatExporter from '../../settings/components/chatExporter/ChatExporter';
-import { AttributesList, ExportStatus } from '../../types/store/SessionTypes';
-import { RootStore, SessionStoreSlice } from '../../types/store/StoreTypes';
+import { AttributesList, ExportStatus, SessionStoreSlice } from '../../types/store/SessionTypes';
+import { RootStore } from '../../types/store/StoreTypes';
 import { UserType } from '../../types/store/UserTypes';
 import UserDataRetriever from '../../utils/UserDataRetriever';
 
@@ -21,9 +21,7 @@ export const useSessionStoreSlice: StateCreator<
 	[],
 	SessionStoreSlice
 > = (set) => ({
-	session: {
-		filterHasFocus: false
-	},
+	session: {},
 	setLoginInfo: (id: string, name: string, displayName?: string, userType?: UserType): void => {
 		set(
 			produce((draft: RootStore) => {
@@ -37,8 +35,7 @@ export const useSessionStoreSlice: StateCreator<
 						chats_be: undefined,
 						xmpp: undefined,
 						websocket: undefined
-					},
-					filterHasFocus: draft.session.filterHasFocus
+					}
 				};
 				UserDataRetriever.getDebouncedUser(id, true);
 			}),
@@ -94,15 +91,6 @@ export const useSessionStoreSlice: StateCreator<
 			}),
 			false,
 			'SESSION/SET_SELECTED_ROOM_ONE_TO_ONE_GROUP'
-		);
-	},
-	setFilterHasFocus: (hasFocus: boolean): void => {
-		set(
-			produce((draft: RootStore) => {
-				draft.session.filterHasFocus = hasFocus;
-			}),
-			false,
-			'SESSION/SET_FILTER_FOCUS'
 		);
 	},
 	setCustomLogo: (logo: string | false): void => {

--- a/src/types/store/SessionTypes.ts
+++ b/src/types/store/SessionTypes.ts
@@ -16,8 +16,7 @@ export type SessionStoreSlice = {
 	setQueueId: (queueId: string) => void;
 	setSelectedRoom: (roomId?: string) => void;
 	setCustomLogo: (logo: string | false) => void;
-	setChatExporting: (roomId?: string) => void;
-	setChatExportStatus: (status: ExportStatus) => void;
+	setChatExporting: (roomId?: string, status?: ExportStatus) => void;
 };
 
 export type Session = {

--- a/src/types/store/SessionTypes.ts
+++ b/src/types/store/SessionTypes.ts
@@ -16,7 +16,8 @@ export type SessionStoreSlice = {
 	setQueueId: (queueId: string) => void;
 	setSelectedRoom: (roomId?: string) => void;
 	setCustomLogo: (logo: string | false) => void;
-	setChatExporting: (roomId?: string, status?: ExportStatus) => void;
+	setChatExporting: (roomId?: string) => void;
+	setChatExportStatus: (status: ExportStatus) => void;
 };
 
 export type Session = {

--- a/src/types/store/SessionTypes.ts
+++ b/src/types/store/SessionTypes.ts
@@ -4,8 +4,21 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import { AccountSettingsAttrs } from '@zextras/carbonio-shell-ui/lib/types/account';
+
 import { UserType } from './UserTypes';
 import { IChatExporter } from '../../settings/components/chatExporter/ChatExporter';
+
+export type SessionStoreSlice = {
+	session: Session;
+	setLoginInfo: (id: string, name: string, displayName?: string, userType?: UserType) => void;
+	setSessionId: (sessionId: string) => void;
+	setAttributes: (attrs: AccountSettingsAttrs) => void;
+	setSelectedRoomOneToOneGroup: (id: string) => void;
+	setCustomLogo: (logo: string | false) => void;
+	setChatExporting: (roomId?: string) => void;
+	setChatExportStatus: (status: ExportStatus) => void;
+};
 
 export type Session = {
 	id?: string;
@@ -21,7 +34,6 @@ export type Session = {
 		websocket: boolean | undefined;
 	};
 	selectedRoomOneToOneGroup?: string;
-	filterHasFocus: boolean;
 	customLogo?: string | false;
 	chatExporting?: {
 		roomId: string;

--- a/src/types/store/SessionTypes.ts
+++ b/src/types/store/SessionTypes.ts
@@ -12,9 +12,9 @@ import { IChatExporter } from '../../settings/components/chatExporter/ChatExport
 export type SessionStoreSlice = {
 	session: Session;
 	setLoginInfo: (id: string, name: string, displayName?: string, userType?: UserType) => void;
-	setQueueId: (queueId: string) => void;
 	setAttributes: (attrs: AccountSettingsAttrs) => void;
-	setSelectedRoomOneToOneGroup: (id: string) => void;
+	setQueueId: (queueId: string) => void;
+	setSelectedRoom: (roomId?: string) => void;
 	setCustomLogo: (logo: string | false) => void;
 	setChatExporting: (roomId?: string) => void;
 	setChatExportStatus: (status: ExportStatus) => void;
@@ -28,7 +28,7 @@ export type Session = {
 	queueId?: string;
 	userType?: UserType;
 	attributes?: AttributesList;
-	selectedRoomOneToOneGroup?: string;
+	selectedRoom?: string;
 	customLogo?: string | false;
 	chatExporting?: {
 		roomId: string;

--- a/src/types/store/SessionTypes.ts
+++ b/src/types/store/SessionTypes.ts
@@ -12,7 +12,7 @@ import { IChatExporter } from '../../settings/components/chatExporter/ChatExport
 export type SessionStoreSlice = {
 	session: Session;
 	setLoginInfo: (id: string, name: string, displayName?: string, userType?: UserType) => void;
-	setSessionId: (sessionId: string) => void;
+	setQueueId: (queueId: string) => void;
 	setAttributes: (attrs: AccountSettingsAttrs) => void;
 	setSelectedRoomOneToOneGroup: (id: string) => void;
 	setCustomLogo: (logo: string | false) => void;
@@ -25,14 +25,9 @@ export type Session = {
 	email?: string;
 	name?: string;
 	displayName?: string;
-	sessionId?: string;
+	queueId?: string;
 	userType?: UserType;
 	attributes?: AttributesList;
-	connections?: {
-		chats_be: boolean | undefined;
-		xmpp: boolean | undefined;
-		websocket: boolean | undefined;
-	};
 	selectedRoomOneToOneGroup?: string;
 	customLogo?: string | false;
 	chatExporting?: {

--- a/src/types/store/StoreTypes.ts
+++ b/src/types/store/StoreTypes.ts
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { AccountSettingsAttrs } from '@zextras/carbonio-shell-ui/lib/types/account';
-
 import { ActiveConversationsMap, FileToUpload, messageActionType } from './ActiveConversationTypes';
 import {
 	ActiveMeetingMap,
@@ -30,9 +28,9 @@ import {
 	TextMessage
 } from './MessageTypes';
 import { RoomsMap } from './RoomTypes';
-import { ExportStatus, Session } from './SessionTypes';
+import { SessionStoreSlice } from './SessionTypes';
 import { UnreadsMap } from './UnreadsCounterTypes';
-import { UsersMap, UserType } from './UserTypes';
+import { UsersMap } from './UserTypes';
 import { MeetingBe } from '../network/models/meetingBeTypes';
 import { MemberBe, RoomBe } from '../network/models/roomBeTypes';
 import { UserBe } from '../network/models/userBeTypes';
@@ -85,18 +83,6 @@ export type MessagesStoreSlice = {
 	) => void;
 	setPlaceholderMessage: (fields: PlaceholderFields) => void;
 	removePlaceholderMessage: (roomId: string, messageId: string) => void;
-};
-
-export type SessionStoreSlice = {
-	session: Session;
-	setFilterHasFocus: (hasFocus: boolean) => void;
-	setLoginInfo: (id: string, name: string, displayName?: string, userType?: UserType) => void;
-	setSessionId: (sessionId: string) => void;
-	setAttributes: (attrs: AccountSettingsAttrs) => void;
-	setSelectedRoomOneToOneGroup: (id: string) => void;
-	setCustomLogo: (logo: string | false) => void;
-	setChatExporting: (roomId?: string) => void;
-	setChatExportStatus: (status: ExportStatus) => void;
 };
 
 export type MarkersStoreSlice = {

--- a/src/utils/FetchUtils.test.ts
+++ b/src/utils/FetchUtils.test.ts
@@ -37,8 +37,7 @@ describe('FetchUtils', () => {
 	test('test fetchApi is called correctly', async () => {
 		spyOnFetch.mockRestore();
 		act(() => {
-			const store = useStore.getState();
-			store.setSessionId('idUser1');
+			useStore.getState().setQueueId('idUser1');
 		});
 
 		// Set appropriate headers
@@ -69,7 +68,7 @@ describe('FetchUtils', () => {
 	test('test uploadFileFetchAPI is called correctly', async () => {
 		act(() => {
 			const store = useStore.getState();
-			store.setSessionId('idUser1');
+			store.setQueueId('idUser1');
 		});
 		const testImageFile = new File([], 'hello.png', { type: 'image/png' });
 

--- a/src/utils/FetchUtils.ts
+++ b/src/utils/FetchUtils.ts
@@ -28,9 +28,9 @@ export const fetchAPI = (
 	headers.append('Content-Type', 'application/json');
 
 	// Add sessionId to headers only id it is already defined
-	const { sessionId } = useStore.getState().session;
-	if (sessionId) {
-		headers.append('queue-id', sessionId);
+	const { queueId } = useStore.getState().session;
+	if (queueId) {
+		headers.append('queue-id', queueId);
 	}
 
 	return fetch(URL, {
@@ -74,9 +74,9 @@ export const uploadFileFetchAPI = (
 			}
 
 			// Add sessionId to headers only if it is already defined
-			const { sessionId } = useStore.getState().session;
-			if (sessionId) {
-				headers.append('session-id', sessionId);
+			const { queueId } = useStore.getState().session;
+			if (queueId) {
+				headers.append('session-id', queueId);
 			}
 			fetch(BASE_PATH + endpoint, {
 				method: requestType,


### PR DESCRIPTION
Reviewed usage and implementation on `SessionStoreSlice`:
- removed `filterHasFocus` data from store and replace it as state into `ConversationFilter.tsx`
- renamed all `sessionId` references and replaced with `queueId`
- renamed `selectedRoomOneToOneGroup` to `selectedRoom`
- removed old reference from `Session` type (es: `connection`, that it was split into a different slice)
- fix `ChatExporter` sonarQube errors