### PR TITLE
refactor: improve users store slice usage ref: WSC-1919

### DIFF
--- a/src/chats/components/UserAvatar.test.tsx
+++ b/src/chats/components/UserAvatar.test.tsx
@@ -109,14 +109,14 @@ const meeting2: MeetingBe = createMockMeeting({
 beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo(user1Info.id, user1Info.name);
-	store.setUserInfo(user1Info);
-	store.setUserInfo(user2Info);
-	store.setUserInfo(user3Info);
-	store.addRoom(room);
-	store.addRoom(roomWithPicture);
-	store.addRoom(singleConversationWithUnloadUser);
-	store.addRoom(roomMuted);
-	store.addRoom(roomMutedWithMeeting);
+	store.setUserInfo([user1Info, user2Info, user3Info]);
+	store.setRooms([
+		room,
+		roomWithPicture,
+		singleConversationWithUnloadUser,
+		roomMuted,
+		roomMutedWithMeeting
+	]);
 	store.addMeeting(meeting);
 	store.addMeeting(meeting2);
 });

--- a/src/chats/components/conversation/Conversation.test.tsx
+++ b/src/chats/components/conversation/Conversation.test.tsx
@@ -61,11 +61,16 @@ const user2Info: User = createMockUser({
 	name: 'User 2'
 });
 
+beforeEach(() => {
+	const store = useStore.getState();
+	store.setLoginInfo(user1Info.id, user1Info.email, user1Info.name);
+	store.setUserInfo([user2Info]);
+	store.setRooms([testRoom, testRoom2]);
+});
+
 describe('Conversation view', () => {
 	test('Display conversation view on small screen and toggle info panel', async () => {
 		mockUseMediaQueryCheck.mockReturnValueOnce(true);
-		const store = useStore.getState();
-		store.addRoom(testRoom);
 		const { user } = setup(<Conversation roomId={testRoom.id} />);
 		const conversationCollapsedView = screen.getByTestId('conversationCollapsedView');
 		expect(conversationCollapsedView).toBeInTheDocument();
@@ -83,10 +88,6 @@ describe('Conversation view', () => {
 
 	test('Display info panel and check data are visible', async () => {
 		mockUseMediaQueryCheck.mockReturnValueOnce(true);
-		const store = useStore.getState();
-		store.addRoom(testRoom);
-		store.setLoginInfo(user1Info.id, user1Info.email, user1Info.name);
-		store.setUserInfo(user2Info);
 		const { user } = setup(<Conversation roomId={testRoom.id} />);
 		const conversationCollapsedView = screen.getByTestId('conversationCollapsedView');
 		expect(conversationCollapsedView).toBeInTheDocument();
@@ -106,11 +107,6 @@ describe('Conversation view', () => {
 	test('Leave a group and check everything is shown correctly', async () => {
 		const spyOnDeleteRoomMember = spyOnRoomsApi(RoomsApiToSpy.DELETE_ROOM_MEMBER);
 		mockUseMediaQueryCheck.mockReturnValue(true);
-		const store = useStore.getState();
-		store.addRoom(testRoom);
-		store.addRoom(testRoom2);
-		store.setLoginInfo(user1Info.id, user1Info.email, user1Info.name);
-		store.setUserInfo(user2Info);
 		mockGoToMainPage.mockReturnValueOnce('main page');
 		const { user } = setup(<Conversation roomId={testRoom.id} />);
 		expect(screen.getByText(/Leave Group/i)).toBeInTheDocument();
@@ -125,8 +121,6 @@ describe('Conversation view', () => {
 
 	test('Display conversation view with darkMode disabled', async () => {
 		mockDarkReaderIsEnabled.mockReturnValueOnce(false);
-		const store = useStore.getState();
-		store.addRoom(testRoom);
 		setup(<Conversation roomId={testRoom.id} />);
 		const ConversationWrapper = screen.getByTestId('ConversationWrapper');
 		expect(ConversationWrapper).toHaveStyle(`background-image: url('papyrus.png')`);
@@ -134,20 +128,12 @@ describe('Conversation view', () => {
 
 	test('Display conversation view with darkMode enabled', async () => {
 		mockDarkReaderIsEnabled.mockReturnValueOnce(true);
-		const store = useStore.getState();
-		store.addRoom(testRoom);
 		setup(<Conversation roomId={testRoom.id} />);
 		const ConversationWrapper = screen.getByTestId('ConversationWrapper');
 		expect(ConversationWrapper).toHaveStyle(`background-image: url('papyrus-dark.png')`);
 	});
 
 	test('Add moderator and check everything is shown correctly', async () => {
-		act(() => {
-			useStore.getState().addRoom(testRoom);
-			useStore.getState().setLoginInfo(user1Info.id, user1Info.email, user1Info.name);
-			useStore.getState().setUserInfo(user1Info);
-			useStore.getState().setUserInfo(user2Info);
-		});
 		setup(<Conversation roomId={testRoom.id} />);
 		act(() => {
 			useStore.getState().promoteMemberToModerator(testRoom.id, user1Info.id);
@@ -167,12 +153,6 @@ describe('Conversation view', () => {
 	});
 
 	test('Remove moderator and check everything is shown correctly', async () => {
-		act(() => {
-			useStore.getState().addRoom(testRoom2);
-			useStore.getState().setLoginInfo(user1Info.id, user1Info.email, user1Info.name);
-			useStore.getState().setUserInfo(user1Info);
-			useStore.getState().setUserInfo(user2Info);
-		});
 		setup(<Conversation roomId={testRoom2.id} />);
 		act(() => {
 			useStore.getState().demoteMemberFromModerator(testRoom2.id, user1Info.id);

--- a/src/chats/components/conversation/ConversationHeader.test.tsx
+++ b/src/chats/components/conversation/ConversationHeader.test.tsx
@@ -108,15 +108,15 @@ describe('Conversation header test', () => {
 	});
 });
 
+beforeEach(() => {
+	const store: RootStore = useStore.getState();
+	store.setLoginInfo(mockPaoloUser.id, mockPaoloUser.name);
+	store.setUserInfo([mockRobertoUser, mockLucaUser, mockGianniUser, mockQuintoUser]);
+	store.addRoom(mockedRoom);
+});
 describe('isWriting functionality', () => {
 	test('is writing appears when someone is writing and disappear if not', async () => {
-		const store: RootStore = useStore.getState();
-		act(() => {
-			store.addRoom(mockedRoom);
-			store.setLoginInfo(mockPaoloUser.id, mockPaoloUser.name);
-			store.setUserInfo(mockRobertoUser);
-			store.setIsWriting(mockedRoom.id, mockRobertoUser.id, true);
-		});
+		useStore.getState().setIsWriting(mockedRoom.id, mockRobertoUser.id, true);
 
 		setup(<ConversationHeader roomId={mockedRoom.id} setInfoPanelOpen={jest.fn()} />);
 
@@ -124,7 +124,7 @@ describe('isWriting functionality', () => {
 		expect(isWriting).toBeInTheDocument();
 
 		act(() => {
-			store.setIsWriting(mockedRoom.id, mockRobertoUser.id, false);
+			useStore.getState().setIsWriting(mockedRoom.id, mockRobertoUser.id, false);
 			jest.advanceTimersByTime(4000);
 		});
 
@@ -133,19 +133,10 @@ describe('isWriting functionality', () => {
 
 	test('is writing label for four or more users that are writing', async () => {
 		const store: RootStore = useStore.getState();
-		act(() => {
-			store.addRoom(mockedRoom);
-			store.setLoginInfo(mockPaoloUser.id, mockPaoloUser.name);
-			store.setUserInfo(mockRobertoUser);
-			store.setUserInfo(mockLucaUser);
-			store.setUserInfo(mockGianniUser);
-			store.setUserInfo(mockQuintoUser);
-
-			store.setIsWriting(mockedRoom.id, mockRobertoUser.id, true);
-			store.setIsWriting(mockedRoom.id, mockGianniUser.id, true);
-			store.setIsWriting(mockedRoom.id, mockLucaUser.id, true);
-			store.setIsWriting(mockedRoom.id, mockQuintoUser.id, true);
-		});
+		store.setIsWriting(mockedRoom.id, mockRobertoUser.id, true);
+		store.setIsWriting(mockedRoom.id, mockGianniUser.id, true);
+		store.setIsWriting(mockedRoom.id, mockLucaUser.id, true);
+		store.setIsWriting(mockedRoom.id, mockQuintoUser.id, true);
 
 		setup(<ConversationHeader roomId={mockedRoom.id} setInfoPanelOpen={jest.fn()} />);
 

--- a/src/chats/components/conversation/MessagesList.test.tsx
+++ b/src/chats/components/conversation/MessagesList.test.tsx
@@ -42,29 +42,25 @@ const userC = createMockUser({ id: 'userC', name: 'userC' });
 const user2Be: User = createMockUser({
 	id: 'user2',
 	email: 'user2@domain.com',
-	name: 'User2',
-	lastSeen: 1234567890
+	name: 'User2'
 });
 
 const user3Be: User = createMockUser({
 	id: 'user3',
 	email: 'user3@domain.com',
-	name: 'User3',
-	lastSeen: 1234567890
+	name: 'User3'
 });
 
 const user1Be: User = createMockUser({
 	id: 'user1',
 	email: 'user1@domain.com',
-	name: 'User1',
-	lastSeen: 1234567890
+	name: 'User1'
 });
 
 const user4Be: User = createMockUser({
 	id: 'user4',
 	email: 'user4@domain.com',
-	name: 'User4',
-	lastSeen: 1234567890
+	name: 'User4'
 });
 
 const room: RoomBe = {

--- a/src/chats/components/conversation/MessagesList.test.tsx
+++ b/src/chats/components/conversation/MessagesList.test.tsx
@@ -43,32 +43,28 @@ const user2Be: User = createMockUser({
 	id: 'user2',
 	email: 'user2@domain.com',
 	name: 'User2',
-	lastSeen: 1234567890,
-	statusMessage: "Hey there! I'm User 2"
+	lastSeen: 1234567890
 });
 
 const user3Be: User = createMockUser({
 	id: 'user3',
 	email: 'user3@domain.com',
 	name: 'User3',
-	lastSeen: 1234567890,
-	statusMessage: "Hey there! I'm User 3"
+	lastSeen: 1234567890
 });
 
 const user1Be: User = createMockUser({
 	id: 'user1',
 	email: 'user1@domain.com',
 	name: 'User1',
-	lastSeen: 1234567890,
-	statusMessage: "Hey there! I'm User 1"
+	lastSeen: 1234567890
 });
 
 const user4Be: User = createMockUser({
 	id: 'user4',
 	email: 'user4@domain.com',
 	name: 'User4',
-	lastSeen: 1234567890,
-	statusMessage: "Hey there! I'm User 4"
+	lastSeen: 1234567890
 });
 
 const room: RoomBe = {

--- a/src/chats/components/conversation/MessagesList.test.tsx
+++ b/src/chats/components/conversation/MessagesList.test.tsx
@@ -355,7 +355,7 @@ describe('render list of messages with history loader visible for first time ope
 		const { result } = renderHook(() => useStore());
 		act(() => {
 			result.current.addRoom(room);
-			result.current.setUserInfo(user2Be);
+			result.current.setUserInfo([user2Be]);
 			result.current.setLoginInfo(user1Be.id, user1Be.name);
 			result.current.setHistoryIsFullyLoaded(room.id);
 			result.current.updateHistory(room.id, [mockedConfigurationMessage]);
@@ -376,7 +376,7 @@ describe('render list of messages with history loader visible for first time ope
 		const { result } = renderHook(() => useStore());
 		act(() => {
 			result.current.addRoom(room);
-			result.current.setUserInfo(user4Be);
+			result.current.setUserInfo([user4Be]);
 			result.current.setHistoryIsFullyLoaded(room.id);
 			result.current.updateHistory(room.id, [mockedAddMemberMessage]);
 			result.current.addCreateRoomMessage(room.id);
@@ -396,7 +396,7 @@ describe('render list of messages with history loader visible for first time ope
 		const { result } = renderHook(() => useStore());
 		act(() => {
 			result.current.addRoom(room);
-			result.current.setUserInfo(user3Be);
+			result.current.setUserInfo([user3Be]);
 			result.current.setHistoryIsFullyLoaded(room.id);
 			result.current.updateHistory(room.id, [mockedRemoveMemberMessage]);
 			result.current.addCreateRoomMessage(room.id);
@@ -455,9 +455,7 @@ describe('Display group of messages', () => {
 		const { result } = renderHook(() => useStore());
 		act(() => {
 			result.current.setLoginInfo('userId', 'User');
-			result.current.setUserInfo(userA);
-			result.current.setUserInfo(userB);
-			result.current.setUserInfo(userC);
+			result.current.setUserInfo([userA, userB, userC]);
 			result.current.addRoom(mockedRoom);
 		});
 
@@ -488,9 +486,7 @@ describe('Display group of messages', () => {
 		const { result } = renderHook(() => useStore());
 		act(() => {
 			result.current.setLoginInfo('userId', 'User');
-			result.current.setUserInfo(userA);
-			result.current.setUserInfo(userB);
-			result.current.setUserInfo(userC);
+			result.current.setUserInfo([userA, userB, userC]);
 			result.current.addRoom(mockedRoom);
 		});
 

--- a/src/chats/components/conversation/footer/MessageComposer.test.tsx
+++ b/src/chats/components/conversation/footer/MessageComposer.test.tsx
@@ -489,7 +489,7 @@ describe('MessageComposer - send message', () => {
 		const store = useStore.getState();
 		store.addRoom(mockedRoomTemporary);
 		store.setLoginInfo(guestUser.id, guestUser.name, guestUser.type);
-		store.setUserInfo(guestUser);
+		store.setUserInfo([guestUser]);
 		setup(<MessageComposer roomId={mockedRoom.id} />);
 
 		expect(screen.queryByTestId(iconAttach)).not.toBeInTheDocument();

--- a/src/chats/components/conversation/footer/MessageReferenceDisplayed.test.tsx
+++ b/src/chats/components/conversation/footer/MessageReferenceDisplayed.test.tsx
@@ -49,8 +49,7 @@ const user1: User = createMockUser({
 	id: 'user1',
 	email: 'user1@domain.com',
 	name: 'User 1', // on DS them will be color #FFA726
-	lastSeen: 1234567890,
-	statusMessage: "Hey there! I'm User 1"
+	lastSeen: 1234567890
 });
 
 const forwardedUser: UserBe = createMockUser({ id: 'forwardedUserId' });

--- a/src/chats/components/conversation/footer/MessageReferenceDisplayed.test.tsx
+++ b/src/chats/components/conversation/footer/MessageReferenceDisplayed.test.tsx
@@ -48,8 +48,7 @@ const myMockedRepliedTextMessage = createMockTextMessage({
 const user1: User = createMockUser({
 	id: 'user1',
 	email: 'user1@domain.com',
-	name: 'User 1', // on DS them will be color #FFA726
-	lastSeen: 1234567890
+	name: 'User 1' // on DS them will be color #FFA726
 });
 
 const forwardedUser: UserBe = createMockUser({ id: 'forwardedUserId' });

--- a/src/chats/components/conversation/footer/MessageReferenceDisplayed.test.tsx
+++ b/src/chats/components/conversation/footer/MessageReferenceDisplayed.test.tsx
@@ -83,9 +83,7 @@ const attachmentTextMessage = createMockTextMessage({
 beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo(loggedUser.id, loggedUser.name);
-	store.setUserInfo(loggedUser);
-	store.setUserInfo(user1);
-	store.setUserInfo(forwardedUser);
+	store.setUserInfo([loggedUser, user1, forwardedUser]);
 	store.addRoom(mockedRoom);
 });
 describe('Message reference displayed', () => {

--- a/src/chats/components/conversation/forwardModal/ForwardMessageModal.test.tsx
+++ b/src/chats/components/conversation/forwardModal/ForwardMessageModal.test.tsx
@@ -43,7 +43,7 @@ const chat3: RoomBe = createMockRoom({ id: 'chat3', name: 'Chat 3', type: RoomTy
 beforeEach(() => {
 	const store: RootStore = useStore.getState();
 	store.setLoginInfo(sessionUser.id, sessionUser.name);
-	store.setUserInfo(user1);
+	store.setUserInfo([user1]);
 	store.addRoom(testRoom);
 	store.addRoom(chat);
 	store.addRoom(chat2);

--- a/src/chats/components/conversation/messageBubbles/Bubble.test.tsx
+++ b/src/chats/components/conversation/messageBubbles/Bubble.test.tsx
@@ -298,12 +298,15 @@ describe('Attachment footer', () => {
 	});
 });
 
+beforeEach(() => {
+	const store: RootStore = useStore.getState();
+	store.setLoginInfo(user1Be.id, user1Be.name);
+	store.addRoom(mockedTempRoom);
+	store.setUserInfo([guestUser, user1Be]);
+});
+
 describe('Message header', () => {
 	test('Sender is guest user', async () => {
-		const store: RootStore = useStore.getState();
-		store.setLoginInfo(user1Be.id, user1Be.name);
-		store.addRoom(mockedTempRoom);
-		store.setUserInfo(guestUser);
 		setup(
 			<Bubble
 				message={mockedMsgFromGuest}
@@ -316,10 +319,6 @@ describe('Message header', () => {
 		expect(guestLabel).toBeInTheDocument();
 	});
 	test('Sender is internal user', async () => {
-		const store: RootStore = useStore.getState();
-		store.setLoginInfo(user1Be.id, user1Be.name);
-		store.addRoom(mockedTempRoom);
-		store.setUserInfo(user1Be);
 		setup(
 			<Bubble
 				message={mockedTextMessageSentByMe}
@@ -338,7 +337,7 @@ beforeEach(() => {
 	store.setLoginInfo(user1Be.id, user1Be.name);
 	store.setAttributes(createMockAttributesList({ carbonioWscMessageDeleteTimeLimit: '5m' }));
 	store.addRoom(mockedTempRoom);
-	store.setUserInfo(user1Be);
+	store.setUserInfo([user1Be]);
 });
 describe('Actions', () => {
 	test('Download an attachment', async () => {

--- a/src/chats/components/conversation/messageBubbles/Bubble.test.tsx
+++ b/src/chats/components/conversation/messageBubbles/Bubble.test.tsx
@@ -36,16 +36,14 @@ const user1Be: User = createMockUser({
 	id: 'user1',
 	email: 'user1@domain.com',
 	name: 'User1',
-	lastSeen: 1234567890,
-	statusMessage: "Hey there! I'm User 1"
+	lastSeen: 1234567890
 });
 
 const user2Be: User = createMockUser({
 	id: 'user2',
 	email: 'user2@domain.com',
 	name: 'User2',
-	lastSeen: 1234567890,
-	statusMessage: "Hey there! I'm User 2"
+	lastSeen: 1234567890
 });
 
 const mockMember1 = createMockMember({ userId: user1Be.id, owner: true });

--- a/src/chats/components/conversation/messageBubbles/Bubble.test.tsx
+++ b/src/chats/components/conversation/messageBubbles/Bubble.test.tsx
@@ -35,15 +35,13 @@ const iconArrowIosDownward = 'icon: ArrowIosDownward';
 const user1Be: User = createMockUser({
 	id: 'user1',
 	email: 'user1@domain.com',
-	name: 'User1',
-	lastSeen: 1234567890
+	name: 'User1'
 });
 
 const user2Be: User = createMockUser({
 	id: 'user2',
 	email: 'user2@domain.com',
-	name: 'User2',
-	lastSeen: 1234567890
+	name: 'User2'
 });
 
 const mockMember1 = createMockMember({ userId: user1Be.id, owner: true });

--- a/src/chats/components/conversation/messageBubbles/ForwardInfo.test.tsx
+++ b/src/chats/components/conversation/messageBubbles/ForwardInfo.test.tsx
@@ -27,7 +27,7 @@ const forwardedInfo = {
 
 beforeEach(() => {
 	const store: RootStore = useStore.getState();
-	store.setUserInfo(forwardedUser);
+	store.setUserInfo([forwardedUser]);
 });
 describe('Forward Info', () => {
 	test('ForwardInfo contains original sender name', () => {

--- a/src/chats/components/conversation/messageBubbles/MessageReactionsList.test.tsx
+++ b/src/chats/components/conversation/messageBubbles/MessageReactionsList.test.tsx
@@ -71,10 +71,7 @@ const reactionChipTestId = 'reaction-chip';
 beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo(loggedUser.id, loggedUser.name);
-	store.setUserInfo(loggedUser);
-	store.setUserInfo(user1);
-	store.setUserInfo(user2);
-	store.setUserInfo(user3);
+	store.setUserInfo([loggedUser, user1, user2, user3]);
 	store.addRoom(room);
 	store.newMessage(simpleTextMessage);
 });

--- a/src/chats/components/conversation/messageBubbles/ReactionChip.test.tsx
+++ b/src/chats/components/conversation/messageBubbles/ReactionChip.test.tsx
@@ -21,10 +21,7 @@ const user3 = createMockUser({ id: 'user3', name: 'User 3' });
 beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo(loggedUser.id, loggedUser.name);
-	store.setUserInfo(loggedUser);
-	store.setUserInfo(user1);
-	store.setUserInfo(user2);
-	store.setUserInfo(user3);
+	store.setUserInfo([loggedUser, user1, user2, user3]);
 });
 
 const chipTestId = 'reaction-chip';

--- a/src/chats/components/conversation/messageBubbles/readByPopoverList/ReadByPopoverList.test.tsx
+++ b/src/chats/components/conversation/messageBubbles/readByPopoverList/ReadByPopoverList.test.tsx
@@ -61,8 +61,7 @@ const ComplexComponent = (): ReactElement => {
 beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo(sessionUser.id, sessionUser.email);
-	store.setUserInfo(user1);
-	store.setUserInfo(user2);
+	store.setUserInfo([user1, user2]);
 	store.newMessage(textMessage);
 	store.updateMarkers(room.id, [user1Marker]);
 });

--- a/src/chats/components/infoPanel/conversationActionsAccordion/ActionsAccordion.test.tsx
+++ b/src/chats/components/infoPanel/conversationActionsAccordion/ActionsAccordion.test.tsx
@@ -47,9 +47,7 @@ const user3Be: UserBe = createMockUser({
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setUserInfo(user1Be);
-	store.setUserInfo(user2Be);
-	store.setUserInfo(user3Be);
+	store.setUserInfo([user1Be, user2Be, user3Be]);
 	store.setLoginInfo(user1Be.id, user1Be.name);
 });
 describe('Actions Accordion', () => {

--- a/src/chats/components/infoPanel/conversationActionsAccordion/ActionsAccordion.test.tsx
+++ b/src/chats/components/infoPanel/conversationActionsAccordion/ActionsAccordion.test.tsx
@@ -27,22 +27,19 @@ const iconChevronDown = 'icon: ChevronDown';
 const user1Be: UserBe = createMockUser({
 	id: 'user1',
 	email: 'user1@domain.com',
-	name: 'User 1',
-	lastSeen: 1234567890
+	name: 'User 1'
 });
 
 const user2Be: UserBe = createMockUser({
 	id: 'user2',
 	email: 'user2@domain.com',
-	name: 'User 2',
-	lastSeen: 1234567890
+	name: 'User 2'
 });
 
 const user3Be: UserBe = createMockUser({
 	id: 'user3',
 	email: 'user3@domain.com',
-	name: 'User 3',
-	lastSeen: 1234567890
+	name: 'User 3'
 });
 
 beforeEach(() => {
@@ -50,6 +47,7 @@ beforeEach(() => {
 	store.setUserInfo([user1Be, user2Be, user3Be]);
 	store.setLoginInfo(user1Be.id, user1Be.name);
 });
+
 describe('Actions Accordion', () => {
 	test('A owner of a group should see the correct actions - More than one owner', () => {
 		const room: RoomBe = createMockRoom({

--- a/src/chats/components/infoPanel/conversationActionsAccordion/ActionsAccordion.test.tsx
+++ b/src/chats/components/infoPanel/conversationActionsAccordion/ActionsAccordion.test.tsx
@@ -28,24 +28,21 @@ const user1Be: UserBe = createMockUser({
 	id: 'user1',
 	email: 'user1@domain.com',
 	name: 'User 1',
-	lastSeen: 1234567890,
-	statusMessage: "Hey there! I'm User 1"
+	lastSeen: 1234567890
 });
 
 const user2Be: UserBe = createMockUser({
 	id: 'user2',
 	email: 'user2@domain.com',
 	name: 'User 2',
-	lastSeen: 1234567890,
-	statusMessage: "Hey there! I'm User 2"
+	lastSeen: 1234567890
 });
 
 const user3Be: UserBe = createMockUser({
 	id: 'user3',
 	email: 'user3@domain.com',
 	name: 'User 3',
-	lastSeen: 1234567890,
-	statusMessage: "Hey there! I'm User 3"
+	lastSeen: 1234567890
 });
 
 beforeEach(() => {

--- a/src/chats/components/infoPanel/conversationActionsAccordion/AddNewMemberAction.test.tsx
+++ b/src/chats/components/infoPanel/conversationActionsAccordion/AddNewMemberAction.test.tsx
@@ -55,7 +55,7 @@ beforeEach(() => {
 	const store = useStore.getState();
 	store.addRoom(mockedRoom);
 	store.setLoginInfo(user1Info.id, user1Info.name);
-	store.setUserInfo(user2Info);
+	store.setUserInfo([user2Info]);
 	store.setAttributes(createMockAttributesList({ carbonioWscMaxGroupMembers: '5' }));
 });
 

--- a/src/chats/components/infoPanel/conversationActionsAccordion/ClearHistoryAction.test.tsx
+++ b/src/chats/components/infoPanel/conversationActionsAccordion/ClearHistoryAction.test.tsx
@@ -52,8 +52,7 @@ describe('clear history action', () => {
 		act(() => {
 			result.current.addRoom(mockedRoom);
 			result.current.setLoginInfo(user1Info.id, user1Info.name);
-			result.current.setUserInfo(user1Info);
-			result.current.setUserInfo(user2Info);
+			result.current.setUserInfo([user1Info, user2Info]);
 			result.current.newMessage(message);
 		});
 

--- a/src/chats/components/infoPanel/conversationActionsAccordion/DeleteConversationAction.test.tsx
+++ b/src/chats/components/infoPanel/conversationActionsAccordion/DeleteConversationAction.test.tsx
@@ -5,7 +5,7 @@
  */
 import React from 'react';
 
-import { screen, act, renderHook } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 
 import DeleteConversationAction from './DeleteConversationAction';
 import useStore from '../../../../store/Store';
@@ -61,13 +61,15 @@ const testRoom2: RoomBe = createMockRoom({
 	]
 });
 
+beforeEach(() => {
+	const store: RootStore = useStore.getState();
+	store.addRoom(testRoom2);
+	store.setLoginInfo(user1Info.id, user1Info.name);
+	store.setUserInfo([user1Info, user2Info]);
+});
+
 describe('delete conversation action', () => {
 	test('open/close modal', async () => {
-		const store: RootStore = useStore.getState();
-		store.addRoom(testRoom2);
-		store.setLoginInfo(user1Info.id, user1Info.name);
-		store.setUserInfo(user1Info);
-		store.setUserInfo(user2Info);
 		const { user } = setup(
 			<DeleteConversationAction roomId={testRoom2.id} type={testRoom2.type} numberOfMembers={2} />
 		);
@@ -80,17 +82,12 @@ describe('delete conversation action', () => {
 	});
 
 	test('delete conversation', async () => {
-		const { result } = renderHook(() => useStore());
-		act(() => {
-			result.current.setLoginInfo(user1Info.id, user1Info.name);
-			result.current.addRoom(testRoom);
-		});
 		mockGoToMainPage.mockReturnValueOnce('main page');
 		const { user } = setup(
 			<DeleteConversationAction roomId={testRoom.id} type={testRoom.type} numberOfMembers={2} />
 		);
 
-		expect(result.current.rooms[testRoom.id]).toBeDefined();
+		expect(useStore.getState().rooms[testRoom.id]).toBeDefined();
 
 		const deleteRoomLabel = screen.getByText(/Delete Group/i);
 		await user.click(deleteRoomLabel);

--- a/src/chats/components/infoPanel/conversationActionsAccordion/EditConversationAction.test.tsx
+++ b/src/chats/components/infoPanel/conversationActionsAccordion/EditConversationAction.test.tsx
@@ -68,8 +68,7 @@ describe('Edit conversation action', () => {
 		const { result } = renderHook(() => useStore());
 		act(() => {
 			result.current.setLoginInfo(user1Info.id, user1Info.name);
-			result.current.setUserInfo(user1Info);
-			result.current.setUserInfo(user2Info);
+			result.current.setUserInfo([user1Info, user2Info]);
 			result.current.addRoom(testRoom2);
 		});
 

--- a/src/chats/components/infoPanel/conversationInfo/ConversationInfo.test.tsx
+++ b/src/chats/components/infoPanel/conversationInfo/ConversationInfo.test.tsx
@@ -84,7 +84,7 @@ describe('Conversation info Details', () => {
 	test('user info should appear as expected', async () => {
 		const store = useStore.getState();
 		store.addRoom(OneToOneRoom);
-		store.setUserInfo(user1Be);
+		store.setUserInfo([user1Be]);
 		setup(<ConversationInfoDetails roomId={OneToOneRoom.id} roomType={RoomType.ONE_TO_ONE} />);
 		expect(screen.getAllByText(user1Be.name)).toHaveLength(1);
 		expect(screen.getByText(user1Be.email)).toBeInTheDocument();
@@ -95,7 +95,7 @@ describe('Conversation Info', () => {
 	test('user info should appear as expected', async () => {
 		const store = useStore.getState();
 		store.addRoom(OneToOneRoom);
-		store.setUserInfo(user1Be);
+		store.setUserInfo([user1Be]);
 		setup(
 			<ConversationInfo
 				roomId={OneToOneRoom.id}

--- a/src/chats/components/infoPanel/conversationInfo/ConversationInfo.test.tsx
+++ b/src/chats/components/infoPanel/conversationInfo/ConversationInfo.test.tsx
@@ -21,8 +21,7 @@ const user1Be: UserBe = createMockUser({
 	id: 'user1',
 	email: 'user1@domain.com',
 	name: 'User 1',
-	lastSeen: 1234567890,
-	statusMessage: "Hey there! I'm User 1"
+	lastSeen: 1234567890
 });
 
 const room = {
@@ -89,11 +88,6 @@ describe('Conversation info Details', () => {
 		setup(<ConversationInfoDetails roomId={OneToOneRoom.id} roomType={RoomType.ONE_TO_ONE} />);
 		expect(screen.getAllByText(user1Be.name)).toHaveLength(1);
 		expect(screen.getByText(user1Be.email)).toBeInTheDocument();
-		if (user1Be.statusMessage != null) {
-			expect(screen.getByText(user1Be.statusMessage)).toBeInTheDocument();
-		}
-		act(() => store.setUserStatusMessage(user1Be.id, 'new status message'));
-		expect(screen.getByText(/new status message/i)).toBeInTheDocument();
 	});
 });
 

--- a/src/chats/components/infoPanel/conversationInfo/ConversationInfo.test.tsx
+++ b/src/chats/components/infoPanel/conversationInfo/ConversationInfo.test.tsx
@@ -11,7 +11,7 @@ import { act, screen } from '@testing-library/react';
 import ConversationInfo from './ConversationInfo';
 import ConversationInfoDetails from './ConversationInfoDetails';
 import useStore from '../../../../store/Store';
-import { createMockUser } from '../../../../tests/createMock';
+import { createMockMember, createMockRoom, createMockUser } from '../../../../tests/createMock';
 import { mockUseMediaQueryCheck } from '../../../../tests/mocks/useMediaQueryCheck';
 import { setup } from '../../../../tests/test-utils';
 import { RoomBe, RoomType } from '../../../../types/network/models/roomBeTypes';
@@ -20,63 +20,33 @@ import { UserBe } from '../../../../types/network/models/userBeTypes';
 const user1Be: UserBe = createMockUser({
 	id: 'user1',
 	email: 'user1@domain.com',
-	name: 'User 1',
-	lastSeen: 1234567890
+	name: 'User 1'
 });
 
-const room = {
+const room: RoomBe = createMockRoom({
 	id: 'Room-Id',
 	name: 'Room Name',
 	description: 'This is the description of the group',
 	type: RoomType.GROUP,
-	createdAt: '1234567',
-	updatedAt: '12345678',
-	pictureUpdatedAt: '123456789',
 	members: [
-		{
-			userId: 'user1',
-			owner: true,
-			temporary: false,
-			external: false
-		},
-		{
-			userId: 'user2',
-			owner: false,
-			temporary: false,
-			external: false
-		},
-		{
-			userId: 'user3',
-			owner: false,
-			temporary: false,
-			external: false
-		}
+		createMockMember({ userId: user1Be.id, owner: true }),
+		createMockMember({ userId: 'user2' }),
+		createMockMember({ userId: 'user3' })
 	]
-};
+});
 
-const OneToOneRoom: RoomBe = {
+const OneToOneRoom: RoomBe = createMockRoom({
 	id: 'One-To-One-Room-Id',
-	name: ' ',
-	description: '',
 	type: RoomType.ONE_TO_ONE,
-	createdAt: '1234567',
-	updatedAt: '12345678',
-	members: [
-		{
-			userId: 'user1',
-			owner: true,
-			temporary: false,
-			external: false
-		}
-	]
-};
+	members: [createMockMember({ userId: user1Be.id, owner: true })]
+});
 
 describe('Conversation info Details', () => {
 	test('group info should appear as expected', async () => {
 		const store = useStore.getState();
 		store.addRoom(room);
 		setup(<ConversationInfoDetails roomId={room.id} roomType="group" />);
-		expect(screen.getByText(room.description)).toBeInTheDocument();
+		expect(screen.getByText(room.description!)).toBeInTheDocument();
 		act(() => store.setRoomDescription(room.id, 'new description'));
 		expect(screen.getByText(/new description/i)).toBeInTheDocument();
 	});
@@ -112,13 +82,15 @@ describe('Conversation Info', () => {
 		setup(
 			<ConversationInfo roomId={room.id} roomType={RoomType.GROUP} setInfoPanelOpen={jest.fn()} />
 		);
-		expect(screen.getByText(room.name)).toBeInTheDocument();
+		expect(screen.getByText(room.name!)).toBeInTheDocument();
 	});
 
 	test('infoPanel take all space', async () => {
 		const store = useStore.getState();
 		store.addRoom(room);
-		setup(<ConversationInfo roomId={room.id} roomType="group" setInfoPanelOpen={jest.fn()} />);
+		setup(
+			<ConversationInfo roomId={room.id} roomType={RoomType.GROUP} setInfoPanelOpen={jest.fn()} />
+		);
 		const messagesIcon = screen.getByTestId('icon: MessageCircleOutline');
 		expect(messagesIcon).toBeInTheDocument();
 	});
@@ -127,7 +99,9 @@ describe('Conversation Info', () => {
 		mockUseMediaQueryCheck.mockReturnValueOnce(true);
 		const store = useStore.getState();
 		store.addRoom(room);
-		setup(<ConversationInfo roomId={room.id} roomType="group" setInfoPanelOpen={jest.fn()} />);
+		setup(
+			<ConversationInfo roomId={room.id} roomType={RoomType.GROUP} setInfoPanelOpen={jest.fn()} />
+		);
 		expect(screen.queryByTestId('icon: MessageCircleOutline')).toBeNull();
 	});
 });

--- a/src/chats/components/infoPanel/conversationInfo/ConversationInfoDetails.tsx
+++ b/src/chats/components/infoPanel/conversationInfo/ConversationInfoDetails.tsx
@@ -15,11 +15,7 @@ import {
 	getRoomDescriptionSelector,
 	getRoomMembers
 } from '../../../../store/selectors/RoomsSelectors';
-import {
-	getUserEmail,
-	getUserName,
-	getUserStatusMessage
-} from '../../../../store/selectors/UsersSelectors';
+import { getUserEmail, getUserName } from '../../../../store/selectors/UsersSelectors';
 import useStore from '../../../../store/Store';
 import { Member, RoomType } from '../../../../types/store/RoomTypes';
 
@@ -37,7 +33,6 @@ const ConversationInfoDetails: FC<ConversationInfoDetailsProps> = ({ roomId, roo
 	const nameLabel = t('conversationInfo.name', 'Name');
 	const emailLabel = t('conversationInfo.email', 'Email');
 	const topicLabel = t('conversationInfo.topic', 'Topic');
-	const statusLabel = t('conversationInfo.status', 'Status');
 
 	const sessionId: string | undefined = useStore((store) => store.session.id);
 	const roomMembers: Member[] | undefined = useStore((state) => getRoomMembers(state, roomId));
@@ -57,9 +52,6 @@ const ConversationInfoDetails: FC<ConversationInfoDetailsProps> = ({ roomId, roo
 		getRoomDescriptionSelector(state, roomId)
 	);
 
-	const userStatusMessage: string | undefined = useStore((state) =>
-		getUserStatusMessage(state, memberId)
-	);
 	const userEmail = useStore((state) => getUserEmail(state, memberId));
 
 	if (roomType === RoomType.ONE_TO_ONE)
@@ -80,13 +72,6 @@ const ConversationInfoDetails: FC<ConversationInfoDetailsProps> = ({ roomId, roo
 							/>
 						)}
 						<ConversationInfoDetailsElement label={memberName} icon="AtOutline" type={nameLabel} />
-						{userStatusMessage && (
-							<ConversationInfoDetailsElement
-								label={userStatusMessage}
-								icon="InfoOutline"
-								type={statusLabel}
-							/>
-						)}
 					</>
 				)}
 			</CustomContainer>

--- a/src/chats/components/infoPanel/conversationInfo/GroupRoomPictureHandler.test.tsx
+++ b/src/chats/components/infoPanel/conversationInfo/GroupRoomPictureHandler.test.tsx
@@ -40,7 +40,7 @@ const testRoom: RoomBe = createMockRoom({
 });
 
 const testRoom2: RoomBe = createMockRoom({
-	id: 'room-test',
+	id: 'room-test2',
 	name: 'A Group',
 	description: 'This is a beautiful description',
 	pictureUpdatedAt: pictureUpdatedAtTime,
@@ -51,13 +51,15 @@ const testRoom2: RoomBe = createMockRoom({
 	]
 });
 
+beforeEach(() => {
+	const store: RootStore = useStore.getState();
+	store.setLoginInfo(user1Info.id, user1Info.name);
+	store.setUserInfo([user1Info, user2Info]);
+	store.setRooms([testRoom, testRoom2]);
+});
+
 describe('Room Picture Handler - groups', () => {
 	test('everything should be rendered - no image', async () => {
-		const store: RootStore = useStore.getState();
-		store.addRoom(testRoom);
-		store.setUserInfo(user1Info);
-		store.setUserInfo(user2Info);
-		store.setLoginInfo(user1Info.id, user1Info.name);
 		const { user } = setup(<GroupRoomPictureHandler roomId={testRoom.id} />);
 
 		const backgroundContainer = screen.getByTestId('background_container');
@@ -72,11 +74,6 @@ describe('Room Picture Handler - groups', () => {
 		expect(updateButton).toBeInTheDocument();
 	});
 	test('everything should be rendered - with image', async () => {
-		const store: RootStore = useStore.getState();
-		store.addRoom(testRoom2);
-		store.setUserInfo(user1Info);
-		store.setUserInfo(user2Info);
-		store.setLoginInfo(user1Info.id, user1Info.name);
 		const { user } = setup(<GroupRoomPictureHandler roomId={testRoom2.id} />);
 
 		const pictureContainer = screen.getByTestId('picture_container');
@@ -96,11 +93,6 @@ describe('Room Picture Handler - groups', () => {
 		const spyOnUpdateRoomPicture = spyOnRoomsApi(RoomsApiToSpy.UPDATE_ROOM_PICTURE);
 		const testImageFile = new File(['hello'], 'hello.png', { type: 'image/png' });
 
-		const store: RootStore = useStore.getState();
-		store.addRoom(testRoom);
-		store.setUserInfo(user1Info);
-		store.setUserInfo(user2Info);
-		store.setLoginInfo(user1Info.id, user1Info.name);
 		const { user } = setup(<GroupRoomPictureHandler roomId={testRoom.id} />);
 
 		const backgroundContainer = screen.getByTestId('background_container');
@@ -123,10 +115,6 @@ describe('Room Picture Handler - groups', () => {
 		const testImageFile = new File([new ArrayBuffer(3000)], 'hello.png', { type: 'image/png' });
 
 		const store: RootStore = useStore.getState();
-		store.addRoom(testRoom2);
-		store.setUserInfo(user1Info);
-		store.setUserInfo(user2Info);
-		store.setLoginInfo(user1Info.id, user1Info.name);
 		store.setAttributes(createMockAttributesList({ carbonioWscMaxRoomPictureSize: '1' }));
 		const { user } = setup(<GroupRoomPictureHandler roomId={testRoom2.id} />);
 
@@ -144,11 +132,6 @@ describe('Room Picture Handler - groups', () => {
 
 	test('delete an image', async () => {
 		const spyOnDeleteRoomPicture = spyOnRoomsApi(RoomsApiToSpy.DELETE_ROOM_PICTURE);
-		const store: RootStore = useStore.getState();
-		store.addRoom(testRoom2);
-		store.setUserInfo(user1Info);
-		store.setUserInfo(user2Info);
-		store.setLoginInfo(user1Info.id, user1Info.name);
 
 		const { user } = setup(<GroupRoomPictureHandler roomId={testRoom2.id} />);
 
@@ -171,13 +154,8 @@ describe('Room Picture Handler - groups', () => {
 	test('delete an image fails ', async () => {
 		const spyOnDeleteRoomPicture = spyOnRoomsApi(RoomsApiToSpy.DELETE_ROOM_PICTURE);
 		spyOnDeleteRoomPicture.mockRejectedValue(false);
-		const store: RootStore = useStore.getState();
-		store.addRoom(testRoom2);
-		store.setUserInfo(user1Info);
-		store.setUserInfo(user2Info);
-		store.setLoginInfo(user1Info.id, user1Info.name);
 
-		const { user } = setup(<GroupRoomPictureHandler roomId={testRoom.id} />);
+		const { user } = setup(<GroupRoomPictureHandler roomId={testRoom2.id} />);
 
 		const pictureContainer = await screen.findByTestId('picture_container');
 		expect(pictureContainer).toBeInTheDocument();

--- a/src/chats/components/infoPanel/conversationInfo/OneToOneRoomPictureHandler.test.tsx
+++ b/src/chats/components/infoPanel/conversationInfo/OneToOneRoomPictureHandler.test.tsx
@@ -30,28 +30,24 @@ const testRoom: RoomBe = createMockRoom({
 	members: [createMockMember({ userId: user1Info.id }), createMockMember({ userId: user2Info.id })]
 });
 
+beforeEach(() => {
+	const store: RootStore = useStore.getState();
+	store.setLoginInfo(user1Info.id, user1Info.name);
+	store.setUserInfo([user1Info, user2Info]);
+	store.addRoom(testRoom);
+	store.setAttributes(createMockAttributesList({ carbonioWscShowUsersPresence: 'TRUE' }));
+});
+
 describe('Room Picture Handler - one_to_one', () => {
 	test('label should show "Last seen" phrase if last_activity is present', () => {
-		const store: RootStore = useStore.getState();
-		store.addRoom(testRoom);
-		store.setUserInfo(user1Info);
-		store.setUserInfo(user2Info);
-		store.setLoginInfo(user1Info.id, user1Info.name);
-		store.setAttributes(createMockAttributesList({ carbonioWscShowUsersPresence: 'TRUE' }));
-		act(() => store.setUserLastActivity(user2Info.id, 1642818617000));
+		act(() => useStore.getState().setUserLastActivity(user2Info.id, 1642818617000));
 		setup(<OneToOneRoomPictureHandler memberId={user2Info.id} />);
 
 		// last activity is 2022/01/22 at 03:30:17
 		expect(screen.getByText(/Last seen 01\/22\/2022/i)).toBeInTheDocument();
 	});
 	test('label should show "Online"', () => {
-		const store: RootStore = useStore.getState();
-		store.addRoom(testRoom);
-		store.setUserInfo(user1Info);
-		store.setUserInfo(user2Info);
-		store.setLoginInfo(user1Info.id, user1Info.name);
-		store.setAttributes(createMockAttributesList({ carbonioWscShowUsersPresence: 'TRUE' }));
-		act(() => store.setUserPresence(user2Info.id, true));
+		act(() => useStore.getState().setUserPresence(user2Info.id, true));
 		setup(<OneToOneRoomPictureHandler memberId={user2Info.id} />);
 
 		expect(screen.getByTestId('user_presence_dot')).toBeInTheDocument();

--- a/src/chats/components/infoPanel/conversationInfo/OneToOneRoomPictureHandler.test.tsx
+++ b/src/chats/components/infoPanel/conversationInfo/OneToOneRoomPictureHandler.test.tsx
@@ -39,7 +39,7 @@ beforeEach(() => {
 });
 
 describe('Room Picture Handler - one_to_one', () => {
-	test('label should show "Last seen" phrase if last_activity is present', () => {
+	test('label should show "Last seen" phrase if lastActivity is present', () => {
 		act(() => useStore.getState().setUserLastActivity(user2Info.id, 1642818617000));
 		setup(<OneToOneRoomPictureHandler memberId={user2Info.id} />);
 

--- a/src/chats/components/infoPanel/conversationParticipantsAccordion/MemberAccordion.test.tsx
+++ b/src/chats/components/infoPanel/conversationParticipantsAccordion/MemberAccordion.test.tsx
@@ -58,8 +58,7 @@ describe('Participants accordion', () => {
 
 		const store = useStore.getState();
 		store.addRoom(room);
-		store.setUserInfo(user1Be);
-		store.setUserInfo(user2Be);
+		store.setUserInfo([user1Be, user2Be]);
 		setup(<MemberAccordion roomId={room.id} />);
 		const titleIsPlural = screen.getByText(/2 members/i);
 		expect(titleIsPlural).toBeInTheDocument();
@@ -79,7 +78,7 @@ describe('Participants accordion', () => {
 
 		const store = useStore.getState();
 		store.addRoom(room);
-		store.setUserInfo(user1Be);
+		store.setUserInfo([user1Be]);
 		setup(<MemberAccordion roomId={room.id} />);
 		const titleIsSingular = screen.getByText(/One member/i);
 		expect(titleIsSingular).toBeInTheDocument();

--- a/src/chats/components/infoPanel/conversationParticipantsAccordion/MemberComponentActions.test.tsx
+++ b/src/chats/components/infoPanel/conversationParticipantsAccordion/MemberComponentActions.test.tsx
@@ -111,7 +111,7 @@ const mockedRoom2 = createMockRoom({
 beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo(user2Info.id, user2Info.name);
-	store.setUserInfo(user1Info);
+	store.setUserInfo([user1Info]);
 	store.addRoom(mockedOneToOne);
 	store.setAttributes(
 		createMockAttributesList({
@@ -232,7 +232,7 @@ describe('participants actions - promote/demote member', () => {
 		const { result } = renderHook(() => useStore());
 		act(() => {
 			result.current.setLoginInfo(user1Info.id, user1Info.name);
-			result.current.setUserInfo(user2Info);
+			result.current.setUserInfo([user2Info]);
 			result.current.addRoom(mockedRoom);
 		});
 
@@ -253,7 +253,7 @@ describe('participants actions - promote/demote member', () => {
 		const { result } = renderHook(() => useStore());
 		act(() => {
 			result.current.setLoginInfo(user1Info.id, user1Info.name);
-			result.current.setUserInfo(user3Info);
+			result.current.setUserInfo([user3Info]);
 			result.current.addRoom(mockedRoom);
 		});
 
@@ -283,7 +283,7 @@ describe('participants actions - delete user', () => {
 	test('open/close modal', async () => {
 		const store = useStore.getState();
 		store.setLoginInfo(user1Info.id, user1Info.name);
-		store.setUserInfo(user2Info);
+		store.setUserInfo([user2Info]);
 		store.addRoom(mockedRoom);
 		const { user } = setup(
 			<RemoveMemberListAction roomId={mockedRoom.id} memberId={user2Info.id} />
@@ -301,7 +301,7 @@ describe('participants actions - delete user', () => {
 		const { result } = renderHook(() => useStore());
 		act(() => {
 			result.current.setLoginInfo(user1Info.id, user1Info.name);
-			result.current.setUserInfo(user2Info);
+			result.current.setUserInfo([user2Info]);
 			result.current.addRoom(mockedRoom);
 		});
 

--- a/src/chats/components/infoPanel/conversationParticipantsAccordion/MemberComponentInfo.test.tsx
+++ b/src/chats/components/infoPanel/conversationParticipantsAccordion/MemberComponentInfo.test.tsx
@@ -27,29 +27,25 @@ const iconMessageCircleOutline = 'icon: MessageCircleOutline';
 const user1Be: UserBe = createMockUser({
 	id: 'user1',
 	email: 'user1@domain.com',
-	name: 'User 1',
-	lastSeen: 1234567890
+	name: 'User 1'
 });
 
 const user2Be: UserBe = createMockUser({
 	id: 'user2',
 	email: 'user2@domain.com',
-	name: 'User 2',
-	lastSeen: 1234567890
+	name: 'User 2'
 });
 
 const user3Be: UserBe = createMockUser({
 	id: 'user3',
 	email: 'user3@domain.com',
-	name: 'User 3',
-	lastSeen: 1234567890
+	name: 'User 3'
 });
 
 const user4Be: UserBe = createMockUser({
 	id: 'user4',
 	email: 'user4@domain.com',
-	name: 'User 4',
-	lastSeen: 1234567890
+	name: 'User 4'
 });
 
 const members = [

--- a/src/chats/components/infoPanel/conversationParticipantsAccordion/MemberComponentInfo.test.tsx
+++ b/src/chats/components/infoPanel/conversationParticipantsAccordion/MemberComponentInfo.test.tsx
@@ -117,13 +117,17 @@ const mockedRoomOneOwner = createMockRoom({
 	members: membersWithOneOwner
 });
 
+beforeEach(() => {
+	const store = useStore.getState();
+	store.setLoginInfo(user1Info.id, user1Info.name);
+	store.addRoom(mockedRoomOneOwner);
+	store.setUserInfo([user1Be, user2Be, user3Be, user4Be]);
+	store.addRoom(mockedRoom);
+});
+
 describe('Participant component info', () => {
 	describe('User is an owner', () => {
 		test('The user is the only owner and sees his element inside list', () => {
-			const store = useStore.getState();
-			store.setLoginInfo('user1', 'User 1');
-			store.addRoom(mockedRoomOneOwner);
-			store.setUserInfo(user1Be);
 			setup(<MemberComponentInfo member={members[0]} roomId={mockedRoomOneOwner.id} />);
 
 			const iAmOwnerAction = screen.getByTestId(iconCrown);
@@ -135,10 +139,6 @@ describe('Participant component info', () => {
 			expect(logoutAction).toBeEnabled();
 		});
 		test('The user is an owner and sees his element inside list', () => {
-			const store = useStore.getState();
-			store.setLoginInfo('user1', 'User 1');
-			store.addRoom(mockedRoom);
-			store.setUserInfo(user1Be);
 			setup(<MemberComponentInfo member={members[0]} roomId={mockedRoom.id} />);
 
 			const participantName = screen.getByText(/User 1/i);
@@ -152,11 +152,9 @@ describe('Participant component info', () => {
 			expect(logoutAction).toBeInTheDocument();
 		});
 		test('The user is an owner and sees a normal user inside list', () => {
-			const store = useStore.getState();
-			store.setLoginInfo('user1', 'User 1');
-			store.setAttributes(createMockAttributesList({ carbonioWscPrivateChatCreation: 'TRUE' }));
-			store.addRoom(mockedRoom);
-			store.setUserInfo(user2Be);
+			useStore
+				.getState()
+				.setAttributes(createMockAttributesList({ carbonioWscPrivateChatCreation: 'TRUE' }));
 			setup(<MemberComponentInfo member={members[1]} roomId={mockedRoom.id} />);
 
 			const participantName = screen.getByText(/User 2/i);
@@ -172,11 +170,10 @@ describe('Participant component info', () => {
 			expect(deleteUserAction).toBeInTheDocument();
 		});
 		test('The user is an owner and sees another owner inside list', () => {
-			const store = useStore.getState();
-			store.setLoginInfo('user1', 'User 1');
-			store.setAttributes(createMockAttributesList({ carbonioWscPrivateChatCreation: 'TRUE' }));
-			store.addRoom(mockedRoom);
-			store.setUserInfo(user3Be);
+			useStore
+				.getState()
+				.setAttributes(createMockAttributesList({ carbonioWscPrivateChatCreation: 'TRUE' }));
+
 			setup(<MemberComponentInfo member={members[2]} roomId={mockedRoom.id} />);
 
 			const participantName = screen.getByText(/User 3/i);
@@ -192,13 +189,12 @@ describe('Participant component info', () => {
 			expect(deleteUserAction).toBeInTheDocument();
 		});
 	});
+
 	describe("User isn't an owner", () => {
 		test('The user is not an owner and sees his element inside list', () => {
 			const store = useStore.getState();
 			store.setLoginInfo('user2', 'User 2');
 			store.setAttributes(createMockAttributesList({ carbonioWscPrivateChatCreation: 'TRUE' }));
-			store.addRoom(mockedRoom);
-			store.setUserInfo(user2Be);
 			setup(<MemberComponentInfo member={members[1]} roomId={mockedRoom.id} />);
 
 			const participantName = screen.getByText(/User 2/i);
@@ -211,8 +207,6 @@ describe('Participant component info', () => {
 			const store = useStore.getState();
 			store.setLoginInfo('user2', 'User 2');
 			store.setAttributes(createMockAttributesList({ carbonioWscPrivateChatCreation: 'TRUE' }));
-			store.addRoom(mockedRoom);
-			store.setUserInfo(user1Be);
 			setup(<MemberComponentInfo member={members[0]} roomId={mockedRoom.id} />);
 
 			const participantName = screen.getByText(/User 1/i);
@@ -228,8 +222,6 @@ describe('Participant component info', () => {
 			const store = useStore.getState();
 			store.setLoginInfo('user2', 'User 2');
 			store.setAttributes(createMockAttributesList({ carbonioWscPrivateChatCreation: 'TRUE' }));
-			store.addRoom(mockedRoom);
-			store.setUserInfo(user4Be);
 			setup(<MemberComponentInfo member={members[3]} roomId={mockedRoom.id} />);
 
 			const participantName = screen.getByText(/User 4/i);
@@ -243,10 +235,6 @@ describe('Participant component info', () => {
 	describe('Subtitle sentence with showUsersPresence capability set to true', () => {
 		test('Label should show Online', () => {
 			const store = useStore.getState();
-			store.setLoginInfo('user1', 'User 1');
-			store.addRoom(mockedRoom);
-			store.setUserInfo(user1Info);
-			store.setUserInfo(user2Info);
 			store.setAttributes(createMockAttributesList({ carbonioWscShowUsersPresence: 'TRUE' }));
 			act(() => store.setUserPresence('user1', true));
 			setup(<MemberComponentInfo member={members[0]} roomId={mockedRoom.id} />);
@@ -255,10 +243,6 @@ describe('Participant component info', () => {
 		});
 		test('Label should show Offline', () => {
 			const store = useStore.getState();
-			store.setLoginInfo('user1', 'User 1');
-			store.addRoom(mockedRoom);
-			store.setUserInfo(user1Info);
-			store.setUserInfo(user2Info);
 			store.setAttributes(createMockAttributesList({ carbonioWscShowUsersPresence: 'TRUE' }));
 			act(() => store.setUserPresence('user1', false));
 			setup(<MemberComponentInfo member={members[1]} roomId={mockedRoom.id} />);
@@ -270,10 +254,6 @@ describe('Participant component info', () => {
 
 		test('Label should show "Last seen" phrase if last_activity is present', () => {
 			const store = useStore.getState();
-			store.setLoginInfo('user1', 'User 1');
-			store.addRoom(mockedRoom);
-			store.setUserInfo(user1Info);
-			store.setUserInfo(user2Info);
 			store.setAttributes(createMockAttributesList({ carbonioWscShowUsersPresence: 'TRUE' }));
 			act(() => store.setUserLastActivity('user2', 1642818617000));
 			setup(<MemberComponentInfo member={members[1]} roomId={mockedRoom.id} />);
@@ -285,10 +265,6 @@ describe('Participant component info', () => {
 	describe('Subtitle sentence with showUsersPresence capability set to false', () => {
 		test('Label should not show Online', () => {
 			const store = useStore.getState();
-			store.setLoginInfo('user1', 'User 1');
-			store.addRoom(mockedRoom);
-			store.setUserInfo(user1Info);
-			store.setUserInfo(user2Info);
 			store.setAttributes(createMockAttributesList({ carbonioWscShowUsersPresence: 'FALSE' }));
 			act(() => store.setUserPresence('user1', true));
 			setup(<MemberComponentInfo member={members[0]} roomId={mockedRoom.id} />);
@@ -298,10 +274,6 @@ describe('Participant component info', () => {
 
 		test('Label should not show Offline', () => {
 			const store = useStore.getState();
-			store.setLoginInfo('user1', 'User 1');
-			store.addRoom(mockedRoom);
-			store.setUserInfo(user1Info);
-			store.setUserInfo(user2Info);
 			store.setAttributes(createMockAttributesList({ carbonioWscShowUsersPresence: 'FALSE' }));
 			act(() => store.setUserPresence('user1', false));
 			setup(<MemberComponentInfo member={members[0]} roomId={mockedRoom.id} />);
@@ -310,10 +282,6 @@ describe('Participant component info', () => {
 
 		test('Label should not show "Last seen" phrase if last_activity is present', () => {
 			const store = useStore.getState();
-			store.setLoginInfo('user1', 'User 1');
-			store.addRoom(mockedRoom);
-			store.setUserInfo(user1Info);
-			store.setUserInfo(user2Info);
 			store.setAttributes(createMockAttributesList({ carbonioWscShowUsersPresence: 'FALSE' }));
 			act(() => store.setUserLastActivity('user2', 1642818617000));
 			setup(<MemberComponentInfo member={members[1]} roomId={mockedRoom.id} />);

--- a/src/chats/components/infoPanel/conversationParticipantsAccordion/MemberComponentInfo.test.tsx
+++ b/src/chats/components/infoPanel/conversationParticipantsAccordion/MemberComponentInfo.test.tsx
@@ -83,32 +83,28 @@ const user1Be: UserBe = createMockUser({
 	id: 'user1',
 	email: 'user1@domain.com',
 	name: 'User 1',
-	lastSeen: 1234567890,
-	statusMessage: "Hey there! I'm User 1"
+	lastSeen: 1234567890
 });
 
 const user2Be: UserBe = createMockUser({
 	id: 'user2',
 	email: 'user2@domain.com',
 	name: 'User 2',
-	lastSeen: 1234567890,
-	statusMessage: "Hey there! I'm User 2"
+	lastSeen: 1234567890
 });
 
 const user3Be: UserBe = createMockUser({
 	id: 'user3',
 	email: 'user3@domain.com',
 	name: 'User 3',
-	lastSeen: 1234567890,
-	statusMessage: "Hey there! I'm User 3"
+	lastSeen: 1234567890
 });
 
 const user4Be: UserBe = createMockUser({
 	id: 'user4',
 	email: 'user4@domain.com',
 	name: 'User 4',
-	lastSeen: 1234567890,
-	statusMessage: "Hey there! I'm User 4"
+	lastSeen: 1234567890
 });
 
 const mockedRoom = createMockRoom({

--- a/src/chats/components/infoPanel/conversationParticipantsAccordion/MemberComponentInfo.test.tsx
+++ b/src/chats/components/infoPanel/conversationParticipantsAccordion/MemberComponentInfo.test.tsx
@@ -12,72 +12,17 @@ import MemberComponentInfo from './MemberComponentInfo';
 import useStore from '../../../../store/Store';
 import {
 	createMockAttributesList,
+	createMockMember,
 	createMockRoom,
 	createMockUser
 } from '../../../../tests/createMock';
 import { setup } from '../../../../tests/test-utils';
 import { RoomType } from '../../../../types/network/models/roomBeTypes';
 import { UserBe } from '../../../../types/network/models/userBeTypes';
-import { User } from '../../../../types/store/UserTypes';
 
 const iconCrown = 'icon: Crown';
 const iconLogOut = 'icon: LogOut';
 const iconMessageCircleOutline = 'icon: MessageCircleOutline';
-
-const user1Info: User = createMockUser({
-	id: 'user1',
-	email: 'user1@domain.com',
-	name: 'User 1'
-});
-
-const user2Info: User = createMockUser({
-	id: 'user2',
-	email: 'user2@domain.com',
-	name: 'User 2',
-	last_activity: 1642818965849
-});
-
-const members = [
-	{
-		userId: 'user1',
-		owner: true,
-		temporary: false,
-		external: false
-	},
-	{
-		userId: 'user2',
-		owner: false,
-		temporary: false,
-		external: false
-	},
-	{
-		userId: 'user3',
-		owner: true,
-		temporary: false,
-		external: false
-	},
-	{
-		userId: 'user4',
-		owner: false,
-		temporary: false,
-		external: false
-	}
-];
-
-const membersWithOneOwner = [
-	{
-		userId: 'user1',
-		owner: true,
-		temporary: false,
-		external: false
-	},
-	{
-		userId: 'user4',
-		owner: false,
-		temporary: false,
-		external: false
-	}
-];
 
 const user1Be: UserBe = createMockUser({
 	id: 'user1',
@@ -107,6 +52,18 @@ const user4Be: UserBe = createMockUser({
 	lastSeen: 1234567890
 });
 
+const members = [
+	createMockMember({ userId: user1Be.id, owner: true }),
+	createMockMember({ userId: user2Be.id }),
+	createMockMember({ userId: user3Be.id, owner: true }),
+	createMockMember({ userId: user4Be.id })
+];
+
+const membersWithOneOwner = [
+	createMockMember({ userId: user1Be.id, owner: true }),
+	createMockMember({ userId: user4Be.id })
+];
+
 const mockedRoom = createMockRoom({
 	type: RoomType.GROUP,
 	members
@@ -119,7 +76,7 @@ const mockedRoomOneOwner = createMockRoom({
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo(user1Info.id, user1Info.name);
+	store.setLoginInfo(user1Be.id, user1Be.name);
 	store.addRoom(mockedRoomOneOwner);
 	store.setUserInfo([user1Be, user2Be, user3Be, user4Be]);
 	store.addRoom(mockedRoom);
@@ -252,7 +209,7 @@ describe('Participant component info', () => {
 			).toBeInTheDocument();
 		});
 
-		test('Label should show "Last seen" phrase if last_activity is present', () => {
+		test('Label should show "Last seen" phrase if lastActivity is present', () => {
 			const store = useStore.getState();
 			store.setAttributes(createMockAttributesList({ carbonioWscShowUsersPresence: 'TRUE' }));
 			act(() => store.setUserLastActivity('user2', 1642818617000));
@@ -280,7 +237,7 @@ describe('Participant component info', () => {
 			expect(screen.queryByText(/Offline/i)).not.toBeInTheDocument();
 		});
 
-		test('Label should not show "Last seen" phrase if last_activity is present', () => {
+		test('Label should not show "Last seen" phrase if lastActivity is present', () => {
 			const store = useStore.getState();
 			store.setAttributes(createMockAttributesList({ carbonioWscShowUsersPresence: 'FALSE' }));
 			act(() => store.setUserLastActivity('user2', 1642818617000));

--- a/src/chats/components/infoPanel/conversationParticipantsAccordion/MemberList.test.tsx
+++ b/src/chats/components/infoPanel/conversationParticipantsAccordion/MemberList.test.tsx
@@ -10,7 +10,7 @@ import { screen, act } from '@testing-library/react';
 
 import MemberList from './MemberList';
 import useStore from '../../../../store/Store';
-import { createMockMember, createMockUser } from '../../../../tests/createMock';
+import { createMockMember, createMockRoom, createMockUser } from '../../../../tests/createMock';
 import { setup } from '../../../../tests/test-utils';
 import { RoomBe } from '../../../../types/network/models/roomBeTypes';
 import { Member, RoomType } from '../../../../types/store/RoomTypes';
@@ -20,32 +20,28 @@ const user1Be: User = createMockUser({
 	id: 'user1',
 	email: 'user1@domain.com',
 	name: 'User 1',
-	lastSeen: 1234567890,
-	statusMessage: "Hey there! I'm User 1"
+	lastSeen: 1234567890
 });
 
 const user2Be: User = createMockUser({
 	id: 'user2',
 	email: 'user2@domain.com',
 	name: 'User 2',
-	lastSeen: 1234567890,
-	statusMessage: "Hey there! I'm User 2"
+	lastSeen: 1234567890
 });
 
 const user3Be: User = createMockUser({
 	id: 'user3',
 	email: 'user3@domain.com',
 	name: 'User 3',
-	lastSeen: 1234567890,
-	statusMessage: "Hey there! I'm User 3"
+	lastSeen: 1234567890
 });
 
 const user4Be: User = createMockUser({
 	id: 'user4',
 	email: 'user4@domain.com',
 	name: 'User 4',
-	lastSeen: 1642818617000,
-	statusMessage: "Hey there! I'm User 4"
+	lastSeen: 1642818617000
 });
 
 const user4MemberBe: Member = createMockMember({
@@ -54,81 +50,53 @@ const user4MemberBe: Member = createMockMember({
 	external: false
 });
 
-const room: RoomBe = {
+const room: RoomBe = createMockRoom({
 	id: 'Room-Id',
-	name: 'Room Name',
-	description: 'This is the description of the group',
 	type: RoomType.GROUP,
-	createdAt: '1234567',
-	updatedAt: '12345678',
-	pictureUpdatedAt: '123456789',
 	members: [
-		{
-			userId: 'user1',
-			owner: true,
-			temporary: false,
-			external: false
-		},
-		{
-			userId: 'user2',
-			owner: false,
-			temporary: false,
-			external: false
-		},
-		{
-			userId: 'user3',
-			owner: false,
-			temporary: false,
-			external: false
-		}
+		createMockMember({ userId: user1Be.id, owner: true }),
+		createMockMember({ userId: user2Be.id }),
+		createMockMember({ userId: user3Be.id })
 	]
-};
+});
+
+beforeEach(() => {
+	const store = useStore.getState();
+	store.addRoom(room);
+	store.setUserInfo(user1Be);
+	store.setUserInfo(user2Be);
+	store.setUserInfo(user3Be);
+	store.setUserInfo(user4Be);
+});
 
 describe('Participants list', () => {
 	test('The participants list should be rendered as expected', async () => {
-		const store = useStore.getState();
-		store.addRoom(room);
-		store.setUserInfo(user1Be);
-		store.setUserInfo(user2Be);
-		store.setUserInfo(user3Be);
 		setup(<MemberList roomId={room.id} />);
 		const list = await screen.findByTestId('members_list');
 		expect(list).toBeInTheDocument();
 		expect(list.children).toHaveLength(3);
-		expect(screen.getByText(/User 1/i)).toBeInTheDocument();
-		expect(screen.getByText(/User 2/i)).toBeInTheDocument();
-		expect(screen.getByText(/User 3/i)).toBeInTheDocument();
+		expect(screen.getByText(user1Be.name)).toBeInTheDocument();
+		expect(screen.getByText(user2Be.name)).toBeInTheDocument();
+		expect(screen.getByText(user3Be.name)).toBeInTheDocument();
 	});
 
 	test('Adding new user inside list should not break the list', async () => {
-		const store = useStore.getState();
-		store.addRoom(room);
-		store.setUserInfo(user1Be);
-		store.setUserInfo(user2Be);
-		store.setUserInfo(user3Be);
-		store.setUserInfo(user4Be);
 		setup(<MemberList roomId={room.id} />);
 		const list = await screen.findByTestId('members_list');
 		expect(list).toBeInTheDocument();
 		expect(list.children).toHaveLength(3);
 
-		act(() => store.addRoomMember(room.id, user4MemberBe));
+		act(() => useStore.getState().addRoomMember(room.id, user4MemberBe));
 		expect(list.children).toHaveLength(4);
 	});
 
 	test('remove user inside list should not break the list', async () => {
-		const store = useStore.getState();
-		store.addRoom(room);
-		store.setUserInfo(user1Be);
-		store.setUserInfo(user2Be);
-		store.setUserInfo(user3Be);
-		store.setUserInfo(user4Be);
 		setup(<MemberList roomId={room.id} />);
 		const list = await screen.findByTestId('members_list');
 		expect(list).toBeInTheDocument();
 		expect(list.children).toHaveLength(3);
 
-		act(() => store.removeRoomMember(room.id, 'user3'));
+		act(() => useStore.getState().removeRoomMember(room.id, user1Be.id));
 		expect(list.children).toHaveLength(2);
 	});
 
@@ -146,11 +114,6 @@ describe('Participants list', () => {
 	});
 
 	test('Search more members inside list', async () => {
-		const store = useStore.getState();
-		store.addRoom(room);
-		store.setUserInfo(user1Be);
-		store.setUserInfo(user2Be);
-		store.setUserInfo(user3Be);
 		const { user } = setup(<MemberList roomId={room.id} />);
 		const searchInput = screen.getByRole('textbox', { name: /Search members/i });
 		const list = await screen.findByTestId('members_list');
@@ -159,17 +122,12 @@ describe('Participants list', () => {
 	});
 
 	test('Search a user that is not in the list', async () => {
-		const store = useStore.getState();
-		store.addRoom(room);
-		store.setUserInfo(user1Be);
-		store.setUserInfo(user2Be);
-		store.setUserInfo(user3Be);
 		const { user } = setup(<MemberList roomId={room.id} />);
 		const searchInput = screen.getByRole('textbox', { name: /Search members/i });
 		const searchIcon = screen.getByTestId('icon: Search');
 		expect(searchIcon).toBeInTheDocument();
 		const list = await screen.findByTestId('members_list');
-		await user.type(searchInput, 'user 4');
+		await user.type(searchInput, user4Be.id);
 
 		const placeholderText = await screen.findByText(
 			/Your search returned no results, try another keyword./i

--- a/src/chats/components/infoPanel/conversationParticipantsAccordion/MemberList.test.tsx
+++ b/src/chats/components/infoPanel/conversationParticipantsAccordion/MemberList.test.tsx
@@ -19,36 +19,28 @@ import { User } from '../../../../types/store/UserTypes';
 const user1Be: User = createMockUser({
 	id: 'user1',
 	email: 'user1@domain.com',
-	name: 'User 1',
-	lastSeen: 1234567890
+	name: 'User 1'
 });
 
 const user2Be: User = createMockUser({
 	id: 'user2',
 	email: 'user2@domain.com',
-	name: 'User 2',
-	lastSeen: 1234567890
+	name: 'User 2'
 });
 
 const user3Be: User = createMockUser({
 	id: 'user3',
 	email: 'user3@domain.com',
-	name: 'User 3',
-	lastSeen: 1234567890
+	name: 'User 3'
 });
 
 const user4Be: User = createMockUser({
 	id: 'user4',
 	email: 'user4@domain.com',
-	name: 'User 4',
-	lastSeen: 1642818617000
+	name: 'User 4'
 });
 
-const user4MemberBe: Member = createMockMember({
-	userId: 'user4',
-	temporary: false,
-	external: false
-});
+const user4MemberBe: Member = createMockMember({ userId: 'user4' });
 
 const room: RoomBe = createMockRoom({
 	id: 'Room-Id',

--- a/src/chats/components/infoPanel/conversationParticipantsAccordion/MemberList.test.tsx
+++ b/src/chats/components/infoPanel/conversationParticipantsAccordion/MemberList.test.tsx
@@ -63,10 +63,7 @@ const room: RoomBe = createMockRoom({
 beforeEach(() => {
 	const store = useStore.getState();
 	store.addRoom(room);
-	store.setUserInfo(user1Be);
-	store.setUserInfo(user2Be);
-	store.setUserInfo(user3Be);
-	store.setUserInfo(user4Be);
+	store.setUserInfo([user1Be, user2Be, user3Be, user4Be]);
 });
 
 describe('Participants list', () => {
@@ -103,9 +100,7 @@ describe('Participants list', () => {
 	test('Search one member inside list', async () => {
 		const store = useStore.getState();
 		store.addRoom(room);
-		store.setUserInfo(user1Be);
-		store.setUserInfo(user2Be);
-		store.setUserInfo(user3Be);
+		store.setUserInfo([user1Be, user2Be, user3Be]);
 		const { user } = setup(<MemberList roomId={room.id} />);
 		const searchInput = screen.getByRole('textbox', { name: /Search members/i });
 		const list = await screen.findByTestId('members_list');

--- a/src/chats/components/secondaryBar/SecondaryBarView.test.tsx
+++ b/src/chats/components/secondaryBar/SecondaryBarView.test.tsx
@@ -111,9 +111,7 @@ beforeEach(() => {
 	store.setChatsBeStatus(true);
 	store.setLoginInfo(user1Be.id, user1Be.name);
 	store.setRooms([mockedGroup1, mockedOneToOne1, mockedGroup2, mockedOneToOne2]);
-	store.setUserInfo(user1Be);
-	store.setUserInfo(user2Be);
-	store.setUserInfo(user3Be);
+	store.setUserInfo([user1Be, user2Be, user3Be]);
 	store.newMessage(mkdTextMsgUser3Group1);
 	store.newMessage(mkdTextMsgUser1OneToOne);
 	store.newMessage(mkdTextMsgUser2OneToOne);

--- a/src/chats/components/secondaryBar/SecondaryBarView.test.tsx
+++ b/src/chats/components/secondaryBar/SecondaryBarView.test.tsx
@@ -28,24 +28,21 @@ const user1Be = createMockUser({
 	id: 'user1Id',
 	email: 'user1@domain.com',
 	name: 'User1',
-	lastSeen: 1234567890,
-	statusMessage: "Hey there! I'm User 1"
+	lastSeen: 1234567890
 });
 
 const user2Be = createMockUser({
 	id: 'user2Id',
 	email: 'user2@domain.com',
 	name: 'User2',
-	lastSeen: 1234567890,
-	statusMessage: "Hey there! I'm User 2"
+	lastSeen: 1234567890
 });
 
 const user3Be = createMockUser({
 	id: 'user3Id',
 	email: 'user3@domain.com',
 	name: 'User3',
-	lastSeen: 1234567890,
-	statusMessage: "Hey there! I'm User 3"
+	lastSeen: 1234567890
 });
 
 const mockedGroup1: RoomBe = createMockRoom({

--- a/src/chats/components/secondaryBar/SecondaryBarView.test.tsx
+++ b/src/chats/components/secondaryBar/SecondaryBarView.test.tsx
@@ -27,22 +27,19 @@ const helloString = 'Hello guys!';
 const user1Be = createMockUser({
 	id: 'user1Id',
 	email: 'user1@domain.com',
-	name: 'User1',
-	lastSeen: 1234567890
+	name: 'User1'
 });
 
 const user2Be = createMockUser({
 	id: 'user2Id',
 	email: 'user2@domain.com',
-	name: 'User2',
-	lastSeen: 1234567890
+	name: 'User2'
 });
 
 const user3Be = createMockUser({
 	id: 'user3Id',
 	email: 'user3@domain.com',
-	name: 'User3',
-	lastSeen: 1234567890
+	name: 'User3'
 });
 
 const mockedGroup1: RoomBe = createMockRoom({

--- a/src/chats/components/secondaryBar/conversationList/CollapsedSidebarListItem.test.tsx
+++ b/src/chats/components/secondaryBar/conversationList/CollapsedSidebarListItem.test.tsx
@@ -21,8 +21,7 @@ const backgroundColor = 'background-color: #cfd5dc';
 const user2Be: User = createMockUser({
 	id: 'user2Id',
 	email: 'user2@domain.com',
-	name: 'User2',
-	lastSeen: 1234567890
+	name: 'User2'
 });
 
 const user1Be: User = createMockUser();

--- a/src/chats/components/secondaryBar/conversationList/CollapsedSidebarListItem.test.tsx
+++ b/src/chats/components/secondaryBar/conversationList/CollapsedSidebarListItem.test.tsx
@@ -22,8 +22,7 @@ const user2Be: User = createMockUser({
 	id: 'user2Id',
 	email: 'user2@domain.com',
 	name: 'User2',
-	lastSeen: 1234567890,
-	statusMessage: "Hey there! I'm User 2"
+	lastSeen: 1234567890
 });
 
 const user1Be: User = createMockUser();

--- a/src/chats/components/secondaryBar/conversationList/CollapsedSidebarListItem.test.tsx
+++ b/src/chats/components/secondaryBar/conversationList/CollapsedSidebarListItem.test.tsx
@@ -41,23 +41,25 @@ const mockedOneToOne: RoomBe = createMockRoom({
 	members: [createMockMember({ userId: user1Be.id }), createMockMember({ userId: user2Be.id })]
 });
 
+beforeEach(() => {
+	const store: RootStore = useStore.getState();
+	store.setLoginInfo(user1Be.id, user1Be.name);
+	store.setUserInfo([user1Be, user2Be]);
+	store.setRooms([mockedOneToOne, mockedGroup]);
+});
+
 describe('Collapsed sidebar list item', () => {
 	test('Group - There is a new message', async () => {
 		const store: RootStore = useStore.getState();
-		store.addRoom(mockedGroup);
-		store.setLoginInfo(user1Be.id, user1Be.name);
-		store.setUserInfo(user1Be);
 		store.incrementUnreadCount(mockedGroup.id);
 		setup(<CollapsedSidebarListItem roomId={mockedGroup.id} />);
 		const unreadBadge = screen.getByTestId('unreads_counter');
 		expect(unreadBadge).toBeInTheDocument();
 		expect(unreadBadge).toHaveStyle('background-color: #2b73d2');
 	});
+
 	test('Group - There is a new message and notifications are muted', async () => {
 		const store: RootStore = useStore.getState();
-		store.addRoom(mockedGroup);
-		store.setLoginInfo(user1Be.id, user1Be.name);
-		store.setUserInfo(user1Be);
 		store.incrementUnreadCount(mockedGroup.id);
 		store.setRoomMuted(mockedGroup.id);
 		setup(<CollapsedSidebarListItem roomId={mockedGroup.id} />);
@@ -67,11 +69,9 @@ describe('Collapsed sidebar list item', () => {
 		const avatarWithNotificationMuted = screen.getByTestId('icon: BellOff');
 		expect(avatarWithNotificationMuted).toBeVisible();
 	});
+
 	test('Group - There is a new message and also a draft', async () => {
 		const store: RootStore = useStore.getState();
-		store.addRoom(mockedGroup);
-		store.setLoginInfo(user1Be.id, user1Be.name);
-		store.setUserInfo(user1Be);
 		store.incrementUnreadCount(mockedGroup.id);
 		store.setRoomMuted(mockedGroup.id);
 		store.setDraftMessage(mockedGroup.id, false, 'hi everyone!');
@@ -82,22 +82,18 @@ describe('Collapsed sidebar list item', () => {
 		const avatarWithWithDraft = screen.getByTestId('icon: Edit2');
 		expect(avatarWithWithDraft).toBeVisible();
 	});
+
 	test('One to one - There is a new message', async () => {
 		const store: RootStore = useStore.getState();
-		store.addRoom(mockedOneToOne);
-		store.setLoginInfo(user1Be.id, user1Be.name);
-		store.setUserInfo(user2Be);
 		store.incrementUnreadCount(mockedOneToOne.id);
 		setup(<CollapsedSidebarListItem roomId={mockedOneToOne.id} />);
 		const unreadBadge = screen.getByTestId('unreads_counter');
 		expect(unreadBadge).toBeInTheDocument();
 		expect(unreadBadge).toHaveStyle('background-color: #2b73d2');
 	});
+
 	test('One to one - There is a new message and notifications are muted', async () => {
 		const store: RootStore = useStore.getState();
-		store.addRoom(mockedOneToOne);
-		store.setLoginInfo(user1Be.id, user1Be.name);
-		store.setUserInfo(user2Be);
 		store.incrementUnreadCount(mockedOneToOne.id);
 		store.setRoomMuted(mockedOneToOne.id);
 		setup(<CollapsedSidebarListItem roomId={mockedOneToOne.id} />);
@@ -107,11 +103,9 @@ describe('Collapsed sidebar list item', () => {
 		const avatarWithNotificationMuted = screen.getByTestId('icon: BellOff');
 		expect(avatarWithNotificationMuted).toBeVisible();
 	});
+
 	test('One to one - There is a new message and also a draft', async () => {
 		const store: RootStore = useStore.getState();
-		store.addRoom(mockedOneToOne);
-		store.setLoginInfo(user1Be.id, user1Be.name);
-		store.setUserInfo(user2Be);
 		store.incrementUnreadCount(mockedOneToOne.id);
 		store.setRoomMuted(mockedOneToOne.id);
 		store.setDraftMessage(mockedOneToOne.id, false, 'hi everyone!');

--- a/src/chats/components/secondaryBar/conversationList/ExpandedSidebarListItem.test.tsx
+++ b/src/chats/components/secondaryBar/conversationList/ExpandedSidebarListItem.test.tsx
@@ -36,22 +36,19 @@ const iconDoneAll = 'icon: DoneAll';
 const user2Be: User = createMockUser({
 	id: 'user2Id',
 	email: 'user2@domain.com',
-	name: 'User2',
-	lastSeen: 1234567890
+	name: 'User2'
 });
 
 const user1Be: User = createMockUser({
 	id: 'user1Id',
 	email: 'user1@domain.com',
-	name: 'User1',
-	lastSeen: 1234567890
+	name: 'User1'
 });
 
 const user4Be: User = createMockUser({
 	id: 'user4Id',
 	email: 'user4@domain.com',
-	name: 'User4',
-	lastSeen: 1234567890
+	name: 'User4'
 });
 
 const mockedGroup: RoomBe = createMockRoom({

--- a/src/chats/components/secondaryBar/conversationList/ExpandedSidebarListItem.test.tsx
+++ b/src/chats/components/secondaryBar/conversationList/ExpandedSidebarListItem.test.tsx
@@ -37,24 +37,21 @@ const user2Be: User = createMockUser({
 	id: 'user2Id',
 	email: 'user2@domain.com',
 	name: 'User2',
-	lastSeen: 1234567890,
-	statusMessage: "Hey there! I'm User 2"
+	lastSeen: 1234567890
 });
 
 const user1Be: User = createMockUser({
 	id: 'user1Id',
 	email: 'user1@domain.com',
 	name: 'User1',
-	lastSeen: 1234567890,
-	statusMessage: "Hey there! I'm User 1"
+	lastSeen: 1234567890
 });
 
 const user4Be: User = createMockUser({
 	id: 'user4Id',
 	email: 'user4@domain.com',
 	name: 'User4',
-	lastSeen: 1234567890,
-	statusMessage: "Hey there! I'm User 4"
+	lastSeen: 1234567890
 });
 
 const mockedGroup: RoomBe = createMockRoom({

--- a/src/chats/components/secondaryBar/conversationList/ExpandedSidebarListItem.test.tsx
+++ b/src/chats/components/secondaryBar/conversationList/ExpandedSidebarListItem.test.tsx
@@ -157,9 +157,7 @@ const mockedAttachmentMessage = createMockTextMessage({
 beforeEach(() => {
 	const store: RootStore = useStore.getState();
 	store.setLoginInfo(user1Be.id, user1Be.name);
-	store.setUserInfo(user1Be);
-	store.setUserInfo(user2Be);
-	store.setUserInfo(user4Be);
+	store.setUserInfo([user1Be, user2Be, user4Be]);
 	store.addRoom(mockedGroup);
 	store.addRoom(mockedOneToOne);
 	store.setAttributes(createMockAttributesList({ carbonioWscShowMessageReads: 'TRUE' }));
@@ -305,7 +303,7 @@ describe('Expanded sidebar list item', () => {
 				const composingMessage = composingStanza(mockedGroup.id, user4Be.id);
 				onComposingMessageStanza.call(useStore.getState().connections.xmppClient, composingMessage);
 			});
-			expect(screen.getByText(`${user4Be.name} is typing...`));
+			expect(screen.getByText(`${user4Be.name} is typing...`)).toBeInTheDocument();
 			jest.advanceTimersByTime(3000);
 			act(() => {
 				const stopWritingMessage = pausedStanza(mockedGroup.id, user4Be.id);
@@ -381,7 +379,7 @@ describe('Expanded sidebar list item', () => {
 				const composingMessage = composingStanza(mockedOneToOne.id, user2Be.id);
 				onComposingMessageStanza.call(useStore.getState().connections.xmppClient, composingMessage);
 			});
-			expect(screen.getByText(`${user2Be.name} is typing...`));
+			expect(screen.getByText(`${user2Be.name} is typing...`)).toBeInTheDocument();
 			jest.advanceTimersByTime(3000);
 			act(() => {
 				const stopWritingMessage = pausedStanza(mockedOneToOne.id, user2Be.id);

--- a/src/chats/components/secondaryBar/virtualRoomWidget/CreateVirtualRoomModal.test.tsx
+++ b/src/chats/components/secondaryBar/virtualRoomWidget/CreateVirtualRoomModal.test.tsx
@@ -42,8 +42,7 @@ const contactUser2: ContactInfo = {
 beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo(sessionUser.id, sessionUser.name);
-	store.setUserInfo(user1);
-	store.setUserInfo(user2);
+	store.setUserInfo([user1, user2]);
 	store.setAttributes(createMockAttributesList());
 });
 

--- a/src/chats/components/secondaryBar/virtualRoomWidget/VirtualRoomsButton.test.tsx
+++ b/src/chats/components/secondaryBar/virtualRoomWidget/VirtualRoomsButton.test.tsx
@@ -21,7 +21,7 @@ const user1 = createMockUser({ id: 'user1', name: 'User 1' });
 beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo(sessionUser.id, sessionUser.name);
-	store.setUserInfo(user1);
+	store.setUserInfo([user1]);
 	store.setAttributes(createMockAttributesList({ carbonioWscVideoCallEnabled: 'TRUE' }));
 });
 

--- a/src/chats/components/secondaryBar/virtualRoomWidget/virtualRoomCard/EditVirtualRoomModal.test.tsx
+++ b/src/chats/components/secondaryBar/virtualRoomWidget/virtualRoomCard/EditVirtualRoomModal.test.tsx
@@ -48,7 +48,7 @@ beforeEach(() => {
 	const store = useStore.getState();
 	store.addRoom(virtualRoom);
 	store.addMeeting(meeting);
-	store.setUserInfo(member1);
+	store.setUserInfo([member1]);
 	mockSearchUsersByFeatureRequest.mockResolvedValueOnce([user1, user2]);
 });
 describe('EditVirtualRoomModal test', () => {

--- a/src/chats/components/secondaryBar/virtualRoomWidget/virtualRoomCard/VirtualRoomCard.test.tsx
+++ b/src/chats/components/secondaryBar/virtualRoomWidget/virtualRoomCard/VirtualRoomCard.test.tsx
@@ -59,8 +59,7 @@ const memberMeeting = createMockMeeting({
 beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo(sessionUser.id, sessionUser.name);
-	store.setUserInfo(sessionUser);
-	store.setUserInfo(userOne);
+	store.setUserInfo([sessionUser, userOne]);
 	store.addRoom(ownerRoom);
 	store.addMeeting(ownerMeeting);
 	store.addRoom(ownersRoom);

--- a/src/chats/components/userPopoverList/UserPopoverList.test.tsx
+++ b/src/chats/components/userPopoverList/UserPopoverList.test.tsx
@@ -30,8 +30,7 @@ const RefComponent = (props: Omit<UserPopoverListProps, 'anchorEl'>): ReactEleme
 beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo(sessionUser.id, sessionUser.email);
-	store.setUserInfo(user1);
-	store.setUserInfo(user2);
+	store.setUserInfo([user1, user2]);
 });
 
 describe('UserPopoverList test', () => {

--- a/src/hooks/useConfigurationMessageLabel.test.tsx
+++ b/src/hooks/useConfigurationMessageLabel.test.tsx
@@ -46,11 +46,8 @@ const oneToOneRoom = createMockRoom({
 beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo(loggedUser.id, loggedUser.name);
-	store.setUserInfo(loggedUser);
-	store.setUserInfo(user1);
-	store.setUserInfo(user2);
-	store.addRoom(groupRoom);
-	store.addRoom(oneToOneRoom);
+	store.setUserInfo([loggedUser, user1, user2]);
+	store.setRooms([groupRoom, oneToOneRoom]);
 });
 describe('useConfigurationMessageLabel', () => {
 	describe('Change room name and topic labels', () => {

--- a/src/hooks/useFilterRoomsOnInput.test.tsx
+++ b/src/hooks/useFilterRoomsOnInput.test.tsx
@@ -33,10 +33,9 @@ const single2 = createMockRoom({
 beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo('sessionId', 'User Name');
-	store.setUserInfo(user1);
-	store.setUserInfo(user2);
-	store.setUserInfo(user3);
+	store.setUserInfo([user1, user2, user3]);
 });
+
 describe('Test useFilterRoomsOnInput custom hook', () => {
 	test('Rooms list is empty with no filters', () => {
 		const { result } = renderHook(() => useFilterRoomsOnInput(''));

--- a/src/meetings/components/MeetingNotification.test.tsx
+++ b/src/meetings/components/MeetingNotification.test.tsx
@@ -24,7 +24,7 @@ const mockRemoveNotification = jest.fn();
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setUserInfo(user);
+	store.setUserInfo([user]);
 	store.addRoom(room);
 	store.addMeeting(meeting);
 });

--- a/src/meetings/components/RecordingInfo.test.tsx
+++ b/src/meetings/components/RecordingInfo.test.tsx
@@ -39,8 +39,7 @@ const meeting: MeetingBe = createMockMeeting({
 beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo(user1.id, 'user1');
-	store.setUserInfo(user1);
-	store.setUserInfo(user2);
+	store.setUserInfo([user1, user2]);
 	store.addRoom(room);
 	store.addMeeting(meeting);
 	store.meetingConnection(meeting.id, false, undefined, false, undefined);

--- a/src/meetings/components/bubblesWrapper/BubblesWrapper.test.tsx
+++ b/src/meetings/components/bubblesWrapper/BubblesWrapper.test.tsx
@@ -65,9 +65,7 @@ const message = createMockTextMessage({
 const storeBasicActiveMeetingSetup = (): { user: UserEvent; store: RootStore } => {
 	const store: RootStore = useStore.getState();
 	store.setLoginInfo(user1.id, user1.name);
-	store.setUserInfo(user1);
-	store.setUserInfo(user2);
-	store.setUserInfo(user3);
+	store.setUserInfo([user1, user2, user3]);
 	store.addRoom(room);
 	store.addMeeting(meeting);
 	store.meetingConnection(meeting.id, false, undefined, false, undefined);

--- a/src/meetings/components/headerMeetingButton/ActiveMeetingParticipantsDropdown.test.tsx
+++ b/src/meetings/components/headerMeetingButton/ActiveMeetingParticipantsDropdown.test.tsx
@@ -50,9 +50,7 @@ const meeting: MeetingBe = createMockMeeting({
 beforeEach(() => {
 	const store: RootStore = useStore.getState();
 	store.setLoginInfo(user1.id, user1.name);
-	store.setUserInfo(user1);
-	store.setUserInfo(user2);
-	store.setUserInfo(user3);
+	store.setUserInfo([user1, user2, user3]);
 	store.addRoom(room);
 	store.addMeeting(meeting);
 	store.startMeeting(meeting.id, '2024-08-25T17:24:28.961+02:00');

--- a/src/meetings/components/headerMeetingButton/ConversationHeaderMeetingButton.test.tsx
+++ b/src/meetings/components/headerMeetingButton/ConversationHeaderMeetingButton.test.tsx
@@ -52,8 +52,7 @@ const storeSetupOneToOneMeeting = (): { store: RootStore } => {
 		type: RoomType.ONE_TO_ONE,
 		members: [createMockMember({ userId: user1.id }), createMockMember({ userId: user2.id })]
 	});
-	store.setUserInfo(user1);
-	store.setUserInfo(user2);
+	store.setUserInfo([user1, user2]);
 	store.setLoginInfo(user1.id, user1.name);
 	store.addRoom(room);
 	const user1Participant: MeetingParticipant = createMockParticipants({ userId: user1.id });
@@ -87,8 +86,7 @@ const storeSetupGroupMeeting = (): { user: UserEvent; store: RootStore } => {
 		type: RoomType.GROUP,
 		members: [createMockMember({ userId: user1.id }), createMockMember({ userId: user2.id })]
 	});
-	store.setUserInfo(user1);
-	store.setUserInfo(user2);
+	store.setUserInfo([user1, user2]);
 	store.setLoginInfo(user1.id, user1.name);
 	store.addRoom(room);
 	store.setAttributes(
@@ -125,9 +123,7 @@ const storeSetupGroupMeetingWithoutMe = (): { user: UserEvent; store: RootStore 
 			createMockMember({ userId: user3.id })
 		]
 	});
-	store.setUserInfo(user1);
-	store.setUserInfo(user2);
-	store.setUserInfo(user3);
+	store.setUserInfo([user1, user2, user3]);
 	store.setLoginInfo(user1.id, user1.name);
 	store.addRoom(room);
 	store.setAttributes(

--- a/src/meetings/components/headerMeetingButton/ParticipantElement.test.tsx
+++ b/src/meetings/components/headerMeetingButton/ParticipantElement.test.tsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 
-import { screen, act } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 
 import ParticipantElement from './ParticipantElement';
 import useStore from '../../../store/Store';
@@ -27,10 +27,7 @@ beforeEach(() => {
 
 describe('ParticipantElement', () => {
 	test('Internal user in meeting', async () => {
-		act(() => {
-			const store = useStore.getState();
-			store.setUserInfo(internalUser);
-		});
+		useStore.getState().setUserInfo([internalUser]);
 
 		setup(
 			<ParticipantElement memberId={internalUser.id} meetingId={activeMeeting.id} isInsideMeeting />
@@ -43,11 +40,7 @@ describe('ParticipantElement', () => {
 	});
 
 	test('External user in meeting', async () => {
-		act(() => {
-			const store = useStore.getState();
-			store.setUserInfo(externalUser);
-		});
-
+		useStore.getState().setUserInfo([externalUser]);
 		setup(
 			<ParticipantElement memberId={externalUser.id} meetingId={activeMeeting.id} isInsideMeeting />
 		);

--- a/src/meetings/components/meetingAccessPoint/MeetingAccessPageMediaSection.test.tsx
+++ b/src/meetings/components/meetingAccessPoint/MeetingAccessPageMediaSection.test.tsx
@@ -50,8 +50,7 @@ const groupMeeting: MeetingBe = createMockMeeting({
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setUserInfo(user1);
-	store.setUserInfo(user2);
+	store.setUserInfo([user1, user2]);
 	store.setLoginInfo(user1.id, user1.name);
 	store.addRoom(groupRoom);
 	store.addMeeting(groupMeeting);

--- a/src/meetings/components/meetingActionsBar/CameraButtonPermissionDenied.test.tsx
+++ b/src/meetings/components/meetingActionsBar/CameraButtonPermissionDenied.test.tsx
@@ -65,8 +65,7 @@ const defaultSetup = (): { user: UserEvent } => {
 beforeEach(() => {
 	const store = useStore.getState();
 	store.setWebsocketStatus(true);
-	store.setUserInfo(user1);
-	store.setUserInfo(user2);
+	store.setUserInfo([user1, user2]);
 	store.setLoginInfo(user1.id, user1.name);
 	store.addRoom(room);
 	store.addMeeting(meeting);

--- a/src/meetings/components/meetingActionsBar/MeetingActionsBar.test.tsx
+++ b/src/meetings/components/meetingActionsBar/MeetingActionsBar.test.tsx
@@ -57,9 +57,7 @@ jest.mock('../../../hooks/useContainerDimensions', () => ({
 beforeEach(() => {
 	const store: RootStore = useStore.getState();
 	store.setLoginInfo(user1.id, user1.name);
-	store.setUserInfo(user1);
-	store.setUserInfo(user2);
-	store.setUserInfo(user3);
+	store.setUserInfo([user1, user2, user3]);
 	store.addRoom(room);
 	store.addMeeting(meeting);
 	store.startMeeting(meeting.id, '2024-08-25T17:24:28.961+02:00');

--- a/src/meetings/components/meetingActionsBar/MoreActionsButton.test.tsx
+++ b/src/meetings/components/meetingActionsBar/MoreActionsButton.test.tsx
@@ -69,15 +69,12 @@ const meetingWithOnePerson: MeetingBe = createMockMeeting({
 
 const storeSetupGroupMeeting = (): { user: UserEvent; store: RootStore } => {
 	const store = useStore.getState();
-	act(() => {
-		store.setUserInfo(user1);
-		store.setUserInfo(user2);
-		store.setUserInfo(user3);
-		store.setLoginInfo(user1.id, user1.name);
-		store.addRoom(room);
-		store.addMeeting(meeting);
-		store.meetingConnection(meeting.id, false, undefined, false, undefined);
-	});
+	store.setUserInfo([user1, user2, user3]);
+	store.setLoginInfo(user1.id, user1.name);
+	store.addRoom(room);
+	store.addMeeting(meeting);
+	store.meetingConnection(meeting.id, false, undefined, false, undefined);
+
 	const spyUseParams = jest.spyOn(ReactRouter, 'useParams');
 	spyUseParams.mockReturnValue({ meetingId: meeting.id });
 	const { user } = routerContextSetup(<MoreActionsButton />, { meetingId: meeting.id });
@@ -88,7 +85,7 @@ const storeSetupGroupMeeting = (): { user: UserEvent; store: RootStore } => {
 const storeSetupGroupMeetingWithOnePerson = (): { user: UserEvent } => {
 	const { result } = renderHook(() => useStore());
 	act(() => {
-		result.current.setUserInfo(user1);
+		result.current.setUserInfo([user1]);
 		result.current.setLoginInfo(user1.id, user1.name);
 		result.current.addRoom(room);
 		result.current.addMeeting(meetingWithOnePerson);
@@ -110,9 +107,7 @@ const customPiPContextValue = {
 
 const storeSetupGroupMeetingPip = (): { user: UserEvent; store: RootStore } => {
 	const store = useStore.getState();
-	store.setUserInfo(user1);
-	store.setUserInfo(user2);
-	store.setUserInfo(user3);
+	store.setUserInfo([user1, user2, user3]);
 	store.setLoginInfo(user1.id, user1.name);
 	store.addRoom(room);
 	store.addMeeting(meeting);

--- a/src/meetings/components/meetingActionsBar/RaiseHandButton.test.tsx
+++ b/src/meetings/components/meetingActionsBar/RaiseHandButton.test.tsx
@@ -57,15 +57,11 @@ const meeting: MeetingBe = createMockMeeting({
 
 const storeSetupGroupMeeting = (): { user: UserEvent; store: RootStore } => {
 	const store = useStore.getState();
-	act(() => {
-		store.setUserInfo(user1);
-		store.setUserInfo(user2);
-		store.setUserInfo(user3);
-		store.setLoginInfo(user1.id, user1.name);
-		store.addRoom(room);
-		store.addMeeting(meeting);
-		store.meetingConnection(meeting.id, false, undefined, false, undefined);
-	});
+	store.setUserInfo([user1, user2, user3]);
+	store.setLoginInfo(user1.id, user1.name);
+	store.addRoom(room);
+	store.addMeeting(meeting);
+	store.meetingConnection(meeting.id, false, undefined, false, undefined);
 	const spyUseParams = jest.spyOn(ReactRouter, 'useParams');
 	spyUseParams.mockReturnValue({ meetingId: meeting.id });
 	const { user } = routerContextSetup(<RaiseHandButton />, { meetingId: meeting.id });

--- a/src/meetings/components/pictureInPicture/PictureInPictureView.test.tsx
+++ b/src/meetings/components/pictureInPicture/PictureInPictureView.test.tsx
@@ -50,8 +50,6 @@ const user2Participant: MeetingParticipant = createMockParticipants({ userId: us
 
 const user3Participant: MeetingParticipant = createMockParticipants({ userId: user3.id });
 
-const user4Participant: MeetingParticipant = createMockParticipants({ userId: user4.id });
-
 const meeting: MeetingBe = createMockMeeting({
 	roomId: room.id,
 	participants: [user1Participant, user2Participant, user3Participant]
@@ -59,9 +57,7 @@ const meeting: MeetingBe = createMockMeeting({
 
 const storeSetupGroupMeetingPip = (): { user: UserEvent; store: RootStore } => {
 	const store = useStore.getState();
-	store.setUserInfo(user1);
-	store.setUserInfo(user2);
-	store.setUserInfo(user3);
+	store.setUserInfo([user1, user2, user3]);
 	store.setLoginInfo(user1.id, user1.name);
 	store.addRoom(room);
 	store.addMeeting(meeting);

--- a/src/meetings/components/sidebar/MeetingConversationAccordion/MeetingConversationAccordion.test.tsx
+++ b/src/meetings/components/sidebar/MeetingConversationAccordion/MeetingConversationAccordion.test.tsx
@@ -67,7 +67,7 @@ const setupBasicGroup = (): { user: UserEvent; store: RootStore } => {
 	act(() => {
 		result.current.setAttributes(createMockAttributesList({ carbonioWscVideoCallEnabled: 'TRUE' }));
 		result.current.setLoginInfo(mockUser1.id, mockUser1.name);
-		result.current.setUserInfo(mockUser2);
+		result.current.setUserInfo([mockUser2]);
 		result.current.addRoom(groupRoom);
 		result.current.addMeeting(groupMeeting);
 		result.current.meetingConnection(groupMeeting.id, false, undefined, false, undefined);

--- a/src/meetings/components/sidebar/ParticipantsAccordion/MeetingParticipantsAccordion.test.tsx
+++ b/src/meetings/components/sidebar/ParticipantsAccordion/MeetingParticipantsAccordion.test.tsx
@@ -53,9 +53,7 @@ const storeSetupGroupMeetingModerator = (): { user: UserEvent; store: RootStore 
 		type: RoomType.GROUP,
 		members: [member1, member2, member3]
 	});
-	store.setUserInfo(user1);
-	store.setUserInfo(user2);
-	store.setUserInfo(user3);
+	store.setUserInfo([user1, user2, user3]);
 	store.setLoginInfo(user1.id, user1.name);
 	store.addRoom(room);
 	const meeting: MeetingBe = createMockMeeting({
@@ -81,8 +79,7 @@ const storeSetupParticipantModerator = (): {
 		type: RoomType.GROUP,
 		members: [member1, member2]
 	});
-	store.setUserInfo(user1);
-	store.setUserInfo(user2);
+	store.setUserInfo([user1, user2]);
 	store.setLoginInfo(user1.id, user1.name);
 	store.addRoom(room);
 

--- a/src/meetings/components/sidebar/waitingListAccordion/WaitingUser.test.tsx
+++ b/src/meetings/components/sidebar/waitingListAccordion/WaitingUser.test.tsx
@@ -19,7 +19,7 @@ const guestUser = createMockUser({ id: 'guestUserId', type: UserType.GUEST });
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setUserInfo(user1);
+	store.setUserInfo([user1]);
 });
 
 describe('WaitingUser tests', () => {
@@ -63,7 +63,7 @@ describe('WaitingUser tests', () => {
 		setup(<WaitingUser meetingId="meetingId" userId={guestUser.id} />);
 		act(() => {
 			const store = useStore.getState();
-			store.setUserInfo(guestUser);
+			store.setUserInfo([guestUser]);
 		});
 
 		const guestLabel = await screen.findByText('Guest');

--- a/src/meetings/components/tile/Tile.test.tsx
+++ b/src/meetings/components/tile/Tile.test.tsx
@@ -51,9 +51,7 @@ const streamRef = React.createRef<HTMLVideoElement | null>();
 const storeBasicActiveMeetingSetup = (): void => {
 	const store: RootStore = useStore.getState();
 	store.setLoginInfo(user1.id, user1.name);
-	store.setUserInfo(user1);
-	store.setUserInfo(user2);
-	store.setUserInfo(user3);
+	store.setUserInfo([user1, user2, user3]);
 	store.addRoom(room);
 	store.addMeeting(meeting);
 	store.meetingConnection(meeting.id, true, undefined, false, undefined);
@@ -62,9 +60,7 @@ const storeBasicActiveMeetingSetup = (): void => {
 const notModeratorActiveMeetingSetup = (): void => {
 	const store: RootStore = useStore.getState();
 	store.setLoginInfo(user2.id, user2.name);
-	store.setUserInfo(user1);
-	store.setUserInfo(user2);
-	store.setUserInfo(user3);
+	store.setUserInfo([user1, user2, user3]);
 	store.addRoom(room);
 	store.addMeeting(meeting);
 	store.meetingConnection(meeting.id, true, undefined, false, undefined);
@@ -72,9 +68,7 @@ const notModeratorActiveMeetingSetup = (): void => {
 
 const storeSetupMyTileAudioOnVideoOff = (): { user: UserEvent; store: RootStore } => {
 	const store: RootStore = useStore.getState();
-	store.setUserInfo(user1);
-	store.setUserInfo(user2);
-	store.setUserInfo(user3);
+	store.setUserInfo([user1, user2, user3]);
 	store.setLoginInfo(user1.id, user1.name);
 	store.addRoom(room);
 	store.addMeeting(meeting);
@@ -95,9 +89,7 @@ const storeSetupMyTileAudioOnVideoOff = (): { user: UserEvent; store: RootStore 
 
 const storeSetupTileAudioOffAndVideoOn = (): { user: UserEvent; store: RootStore } => {
 	const store: RootStore = useStore.getState();
-	store.setUserInfo(user1);
-	store.setUserInfo(user2);
-	store.setUserInfo(user3);
+	store.setUserInfo([user1, user2, user3]);
 	store.setLoginInfo(user1.id, user1.name);
 	store.addRoom(room);
 	store.addMeeting(meeting);
@@ -118,9 +110,7 @@ const storeSetupTileAudioOffAndVideoOn = (): { user: UserEvent; store: RootStore
 
 const setupActiveMeeting = (): void => {
 	const store: RootStore = useStore.getState();
-	store.setUserInfo(user1);
-	store.setUserInfo(user2);
-	store.setUserInfo(user3);
+	store.setUserInfo([user1, user2, user3]);
 	store.setLoginInfo(user1.id, user1.name);
 	store.addRoom(room);
 	store.addMeeting(meeting);
@@ -143,9 +133,7 @@ const setupActiveMeeting = (): void => {
 
 const storeSetupTileAudioOnAndVideoOff = (): { user: UserEvent; store: RootStore } => {
 	const store: RootStore = useStore.getState();
-	store.setUserInfo(user1);
-	store.setUserInfo(user2);
-	store.setUserInfo(user3);
+	store.setUserInfo([user1, user2, user3]);
 	store.setLoginInfo(user1.id, user1.name);
 	store.addRoom(room);
 	store.addMeeting(meeting);

--- a/src/meetings/components/whoIsSpeaking/WhoIsSpeaking.test.tsx
+++ b/src/meetings/components/whoIsSpeaking/WhoIsSpeaking.test.tsx
@@ -56,9 +56,7 @@ const centralTileScreen: TileData = {
 
 beforeEach(() => {
 	const store: RootStore = useStore.getState();
-	store.setUserInfo(user1);
-	store.setUserInfo(user2);
-	store.setUserInfo(user3);
+	store.setUserInfo([user1, user2, user3]);
 	store.setLoginInfo(user1.id, user1.name);
 	store.addRoom(room);
 	store.addMeeting(meeting);

--- a/src/meetings/views/AccessPage.test.tsx
+++ b/src/meetings/views/AccessPage.test.tsx
@@ -67,8 +67,7 @@ const meetingForWaitingRoom: MeetingBe = createMockMeeting({
 const setupGroupForAccessPage = (): { user: UserEvent; store: RootStore } => {
 	const { result } = renderHook(() => useStore());
 	act(() => {
-		result.current.setUserInfo(user1);
-		result.current.setUserInfo(user2);
+		result.current.setUserInfo([user1, user2, user3]);
 		result.current.setLoginInfo(user3.id, user3.name);
 		result.current.addRoom(groupRoom);
 		result.current.addMeeting(groupMeeting);
@@ -85,8 +84,7 @@ const setupGroupForAccessPage = (): { user: UserEvent; store: RootStore } => {
 const setupAccessPage = (): { user: UserEvent; store: RootStore } => {
 	const { result } = renderHook(() => useStore());
 	act(() => {
-		result.current.setUserInfo(user3);
-		result.current.setUserInfo(user2);
+		result.current.setUserInfo([user2, user3]);
 		result.current.setLoginInfo(user2.id, user2.name);
 		result.current.addRoom(groupForWaitingRoom);
 		result.current.addMeeting(meetingForWaitingRoom);

--- a/src/meetings/views/MeetingSkeleton.test.tsx
+++ b/src/meetings/views/MeetingSkeleton.test.tsx
@@ -64,9 +64,7 @@ const meeting: MeetingBe = createMockMeeting({
 
 const storeSetupGroupMeetingSkeleton = (): { user: UserEvent; store: RootStore } => {
 	const store = useStore.getState();
-	store.setUserInfo(user1);
-	store.setUserInfo(user2);
-	store.setUserInfo(user3);
+	store.setUserInfo([user1, user2, user3]);
 	store.setLoginInfo(user1.id, user1.name);
 	store.addRoom(room);
 	store.addMeeting(meeting);

--- a/src/network/apis/UsersApi.ts
+++ b/src/network/apis/UsersApi.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { forEach, join, map } from 'lodash';
+import { join, map } from 'lodash';
 
 import useStore from '../../store/Store';
 import { RequestType } from '../../types/network/apis/IBaseAPI';
@@ -26,7 +26,7 @@ class UsersApi implements IUsersApi {
 	public getUser(userId: string): Promise<GetUserResponse> {
 		const { setUserInfo } = useStore.getState();
 		return fetchAPI(`users/${userId}`, RequestType.GET).then((resp: GetUserResponse) => {
-			setUserInfo(resp);
+			setUserInfo([resp]);
 			return resp;
 		});
 	}
@@ -35,7 +35,7 @@ class UsersApi implements IUsersApi {
 		const { setUserInfo } = useStore.getState();
 		const ids = map(userIds, (id) => `userIds=${id}`);
 		return fetchAPI(`users?${join(ids, '&')}`, RequestType.GET).then((resp: GetUsersResponse) => {
-			forEach(resp, (user) => setUserInfo(user));
+			setUserInfo(resp);
 			return resp;
 		});
 	}

--- a/src/network/websocket/wsConversationEventsHandler.test.ts
+++ b/src/network/websocket/wsConversationEventsHandler.test.ts
@@ -40,7 +40,6 @@ const room: RoomBe = createMockRoom({
 beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo(sessionUser.id, sessionUser.name);
-	store.setUserInfo(sessionUser);
 	store.addRoom(room);
 });
 

--- a/src/network/xmpp/handlers/presenceHandler.test.ts
+++ b/src/network/xmpp/handlers/presenceHandler.test.ts
@@ -19,7 +19,7 @@ const mockUser = createMockUser({ id: 'userId-mock', name: 'User Mock' });
 beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo(loggedUser.id, loggedUser.name);
-	store.setUserInfo(mockUser);
+	store.setUserInfo([mockUser]);
 });
 
 describe('XMPP presenceHandler', () => {

--- a/src/network/xmpp/utility/displayMessageBrowserNotification.test.ts
+++ b/src/network/xmpp/utility/displayMessageBrowserNotification.test.ts
@@ -21,7 +21,7 @@ const user = createMockUser({ id: 'userId', name: 'User' });
 beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo(loggedUser.id, loggedUser.name);
-	store.setUserInfo(user);
+	store.setUserInfo([user]);
 	store.addRoom(room);
 });
 describe('Test display message browser notification', () => {

--- a/src/network/xmpp/utility/displayReactionBrowserNotification.test.ts
+++ b/src/network/xmpp/utility/displayReactionBrowserNotification.test.ts
@@ -35,7 +35,7 @@ const messageFromUser = createMockTextMessage({
 beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo(loggedUser.id, loggedUser.name);
-	store.setUserInfo(user);
+	store.setUserInfo([user]);
 	store.addRoom(room);
 	store.newMessage(messageFromMe);
 	store.newMessage(messageFromUser);

--- a/src/settings/components/Settings.test.tsx
+++ b/src/settings/components/Settings.test.tsx
@@ -23,16 +23,14 @@ const userWithoutImage: UserBe = createMockUser({
 	id: 'user1',
 	email: 'user1@domain.com',
 	name: 'User 1',
-	lastSeen: 1234567890,
-	statusMessage: "Hey there! I'm User 1"
+	lastSeen: 1234567890
 });
 
 const userWithImage: UserBe = createMockUser({
 	id: 'user1',
 	email: 'user1@domain.com',
 	name: 'User 1',
-	lastSeen: 1234567890,
-	statusMessage: "Hey there! I'm User 1"
+	lastSeen: 1234567890
 });
 
 const notificationsSettingsObject: NotificationsSettingsType = {

--- a/src/settings/components/Settings.test.tsx
+++ b/src/settings/components/Settings.test.tsx
@@ -19,14 +19,7 @@ import { NotificationsSettingsType } from '../../utils/localStorageUtils';
 
 const squareIcon = 'icon: Square';
 
-const userWithoutImage: UserBe = createMockUser({
-	id: 'user1',
-	email: 'user1@domain.com',
-	name: 'User 1',
-	lastSeen: 1234567890
-});
-
-const userWithImage: UserBe = createMockUser({
+const user1: UserBe = createMockUser({
 	id: 'user1',
 	email: 'user1@domain.com',
 	name: 'User 1',
@@ -49,12 +42,14 @@ const notificationsSettingsObjectFalse: NotificationsSettingsType = {
 
 const dataTestid = 'data-testid';
 
+beforeEach(() => {
+	const store: RootStore = useStore.getState();
+	store.setUserInfo([user1]);
+	store.setLoginInfo(user1.id, user1.name, user1.name);
+});
 describe('Settings view', () => {
 	describe('Notifications Settings', () => {
 		test('desktop notification checkbox active', async () => {
-			const store: RootStore = useStore.getState();
-			store.setUserInfo(userWithImage);
-			store.setLoginInfo(userWithImage.id, userWithImage.name, userWithImage.name);
 			setup(
 				<NotificationsSettings
 					updatedNotificationsSettings={notificationsSettingsObject}
@@ -66,9 +61,6 @@ describe('Settings view', () => {
 		});
 
 		test('desktop notification checkbox not active', async () => {
-			const store: RootStore = useStore.getState();
-			store.setUserInfo(userWithImage);
-			store.setLoginInfo(userWithImage.id, userWithImage.name, userWithImage.name);
 			setup(
 				<NotificationsSettings
 					updatedNotificationsSettings={notificationsSettingsObjectFalse}
@@ -80,9 +72,6 @@ describe('Settings view', () => {
 		});
 
 		test('desktop notification sounds switch active', async () => {
-			const store: RootStore = useStore.getState();
-			store.setUserInfo(userWithImage);
-			store.setLoginInfo(userWithImage.id, userWithImage.name, userWithImage.name);
 			setup(
 				<NotificationsSettings
 					updatedNotificationsSettings={notificationsSettingsObject}
@@ -95,9 +84,6 @@ describe('Settings view', () => {
 		});
 
 		test('desktop notification sounds switch not active', async () => {
-			const store: RootStore = useStore.getState();
-			store.setUserInfo(userWithImage);
-			store.setLoginInfo(userWithImage.id, userWithImage.name, userWithImage.name);
 			setup(
 				<NotificationsSettings
 					updatedNotificationsSettings={notificationsSettingsObjectFalse}
@@ -110,9 +96,6 @@ describe('Settings view', () => {
 		});
 
 		test('waiting room access notifications active', async () => {
-			const store: RootStore = useStore.getState();
-			store.setUserInfo(userWithImage);
-			store.setLoginInfo(userWithImage.id, userWithImage.name, userWithImage.name);
 			setup(
 				<NotificationsSettings
 					updatedNotificationsSettings={notificationsSettingsObject}
@@ -125,9 +108,6 @@ describe('Settings view', () => {
 		});
 
 		test('waiting room access notifications not active', async () => {
-			const store: RootStore = useStore.getState();
-			store.setUserInfo(userWithImage);
-			store.setLoginInfo(userWithImage.id, userWithImage.name, userWithImage.name);
 			setup(
 				<NotificationsSettings
 					updatedNotificationsSettings={notificationsSettingsObjectFalse}
@@ -140,9 +120,6 @@ describe('Settings view', () => {
 		});
 
 		test('waiting room access notifications sounds active', async () => {
-			const store: RootStore = useStore.getState();
-			store.setUserInfo(userWithImage);
-			store.setLoginInfo(userWithImage.id, userWithImage.name, userWithImage.name);
 			setup(
 				<NotificationsSettings
 					updatedNotificationsSettings={notificationsSettingsObject}
@@ -155,9 +132,6 @@ describe('Settings view', () => {
 		});
 
 		test('waiting room access notifications sounds not active', async () => {
-			const store: RootStore = useStore.getState();
-			store.setUserInfo(userWithImage);
-			store.setLoginInfo(userWithImage.id, userWithImage.name, userWithImage.name);
 			setup(
 				<NotificationsSettings
 					updatedNotificationsSettings={notificationsSettingsObjectFalse}
@@ -172,9 +146,6 @@ describe('Settings view', () => {
 
 	describe('Meeting settings', () => {
 		test('Meeting section checkboxes', () => {
-			const store: RootStore = useStore.getState();
-			store.setUserInfo(userWithoutImage);
-			store.setLoginInfo(userWithoutImage.id, userWithoutImage.name, userWithoutImage.name);
 			setup(<Settings />);
 
 			const meetingContainer = screen.getByTestId('meeting_settings_container');
@@ -193,8 +164,6 @@ describe('Settings view', () => {
 				);
 			});
 			const store: RootStore = useStore.getState();
-			store.setUserInfo(userWithoutImage);
-			store.setLoginInfo(userWithoutImage.id, userWithoutImage.name, userWithoutImage.name);
 			store.setAttributes(createMockAttributesList({ carbonioWscVideoCallEnabled: 'FALSE' }));
 			const { user } = setup(<Settings />);
 
@@ -214,8 +183,6 @@ describe('Settings view', () => {
 	describe('Recording settings', () => {
 		test('Recording enabled', () => {
 			const store: RootStore = useStore.getState();
-			store.setUserInfo(userWithoutImage);
-			store.setLoginInfo(userWithoutImage.id, userWithoutImage.name, userWithoutImage.name);
 			store.setAttributes(createMockAttributesList());
 			setup(<Settings />);
 
@@ -224,8 +191,6 @@ describe('Settings view', () => {
 		});
 		test('Meeting section with recording disabled', () => {
 			const store: RootStore = useStore.getState();
-			store.setUserInfo(userWithoutImage);
-			store.setLoginInfo(userWithoutImage.id, userWithoutImage.name, userWithoutImage.name);
 			store.setAttributes(createMockAttributesList({ carbonioWscRecordingEnabled: 'FALSE' }));
 			setup(<Settings />);
 
@@ -235,8 +200,6 @@ describe('Settings view', () => {
 
 		test('Reset recording folder', async () => {
 			const store: RootStore = useStore.getState();
-			store.setUserInfo(userWithoutImage);
-			store.setLoginInfo(userWithoutImage.id, userWithoutImage.name, userWithoutImage.name);
 			store.setAttributes(createMockAttributesList());
 			localStorage.setItem(
 				'ChatsRecordingSettings',

--- a/src/settings/components/Settings.test.tsx
+++ b/src/settings/components/Settings.test.tsx
@@ -22,8 +22,7 @@ const squareIcon = 'icon: Square';
 const user1: UserBe = createMockUser({
 	id: 'user1',
 	email: 'user1@domain.com',
-	name: 'User 1',
-	lastSeen: 1234567890
+	name: 'User 1'
 });
 
 const notificationsSettingsObject: NotificationsSettingsType = {

--- a/src/settings/components/WaitingListSnackbar.test.tsx
+++ b/src/settings/components/WaitingListSnackbar.test.tsx
@@ -28,8 +28,7 @@ const meeting = createMockMeeting({
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setUserInfo(user);
-	store.setUserInfo(user0);
+	store.setUserInfo([user, user0]);
 	store.addRoom(room);
 	store.addMeeting(meeting);
 });

--- a/src/settings/components/chatExporter/ChatItem.test.tsx
+++ b/src/settings/components/chatExporter/ChatItem.test.tsx
@@ -40,10 +40,8 @@ const groupRoom = createMockRoom({
 beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo(loggedUser.id, loggedUser.name);
-	store.setUserInfo(loggedUser);
-	store.setUserInfo(otherUser);
-	store.addRoom(singleRoom);
-	store.addRoom(groupRoom);
+	store.setUserInfo([loggedUser, otherUser]);
+	store.setRooms([singleRoom, groupRoom]);
 });
 describe('ChatItem test', () => {
 	test('1-to-1 ChatItem displays user name', () => {

--- a/src/store/selectors/UsersSelectors.ts
+++ b/src/store/selectors/UsersSelectors.ts
@@ -35,11 +35,6 @@ export const getUserEmail = (store: RootStore, id: string): string | undefined =
 	return store.users[id]?.email;
 };
 
-export const getUserStatusMessage = (store: RootStore, id: string): string | undefined => {
-	UserDataRetriever.getDebouncedUser(id);
-	return store.users[id]?.statusMessage;
-};
-
 export const getIsUserGuest = (store: RootStore, id: string): boolean | undefined => {
 	UserDataRetriever.getDebouncedUser(id);
 	return store.users[id]?.type === UserType.GUEST;

--- a/src/store/selectors/UsersSelectors.ts
+++ b/src/store/selectors/UsersSelectors.ts
@@ -26,7 +26,7 @@ export const getUserName = (store: RootStore, id: string): string => {
 };
 
 export const getUserLastActivity = (store: RootStore, id: string): number | undefined =>
-	store.users[id]?.last_activity;
+	store.users[id]?.lastActivity;
 
 export const getUserOnline = (store: RootStore, id: string): boolean => !!store.users[id]?.online;
 

--- a/src/store/slices/ConnectionStoreSlice.ts
+++ b/src/store/slices/ConnectionStoreSlice.ts
@@ -58,7 +58,7 @@ export const useConnectionsStoreSlice: StateCreator<
 					draft.users[user.id] = {
 						...draft.users[user.id],
 						online: undefined,
-						last_activity: undefined
+						lastActivity: undefined
 					};
 				});
 				draft.messages = {};

--- a/src/store/slices/ConnectionsStoreSlice.test.ts
+++ b/src/store/slices/ConnectionsStoreSlice.test.ts
@@ -58,7 +58,7 @@ describe('Connections slice', () => {
 		// API effects to store
 		act(() => {
 			result.current.setLoginInfo('userId', 'User');
-			result.current.setUserInfo(user);
+			result.current.setUserInfo([user]);
 			result.current.setRooms([room1, room2]);
 		});
 
@@ -67,7 +67,7 @@ describe('Connections slice', () => {
 		// XMPP effects to store
 		act(() => {
 			result.current.setLoginInfo('userId', 'User');
-			result.current.setUserInfo(user);
+			result.current.setUserInfo([user]);
 			result.current.newInboxMessage(message1);
 			result.current.updateHistory(room1.id, [message1]);
 			result.current.updateHistory(room2.id, [message2]);

--- a/src/store/slices/UsersStoreSlice.test.ts
+++ b/src/store/slices/UsersStoreSlice.test.ts
@@ -1,0 +1,118 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { size } from 'lodash';
+
+import { createMockUser } from '../../tests/createMock';
+import { UserType } from '../../types/store/UserTypes';
+import useStore from '../Store';
+
+const user1 = createMockUser({ id: 'user1-id', email: 'user1@test.com', name: 'User 1' });
+
+const user2 = createMockUser({
+	id: 'user2-id',
+	email: 'user2@test.com',
+	name: 'User 2',
+	type: UserType.GUEST
+});
+
+describe('UsersStoreSlice tests', () => {
+	describe('userInfo', () => {
+		test('Set first users', () => {
+			useStore.getState().setUserInfo([user1, user2]);
+
+			const store = useStore.getState();
+			expect(size(store.users)).toBe(2);
+			expect(store.users[user1.id]).toEqual(user1);
+			expect(store.users[user2.id]).toEqual(user2);
+		});
+
+		test('setUserInfo should not override existing users', () => {
+			useStore.setState({
+				users: {
+					[user1.id]: user1
+				}
+			});
+			useStore.getState().setUserInfo([user2]);
+
+			const store = useStore.getState();
+			expect(size(store.users)).toBe(2);
+			expect(store.users[user1.id]).toEqual(user1);
+			expect(store.users[user2.id]).toEqual(user2);
+		});
+
+		test('Add user info after setting presence do not clear presence', () => {
+			const store = useStore.getState();
+			store.setUserPresence(user1.id, true);
+			store.setUserInfo([user1]);
+
+			expect(useStore.getState().users[user1.id].online).toBe(true);
+		});
+	});
+
+	describe('presence', () => {
+		test('Set user presence', () => {
+			const store = useStore.getState();
+			store.setUserInfo([user1]);
+			store.setUserPresence(user1.id, true);
+
+			expect(useStore.getState().users[user1.id].online).toBe(true);
+		});
+
+		test('Set user presence to false', () => {
+			const store = useStore.getState();
+			store.setUserInfo([user1]);
+			store.setUserPresence(user1.id, false);
+
+			expect(useStore.getState().users[user1.id].online).toBe(false);
+		});
+
+		test('Presence can be set also for non existing users', () => {
+			const store = useStore.getState();
+			store.setUserPresence(user1.id, true);
+
+			expect(useStore.getState().users[user1.id].online).toBe(true);
+		});
+	});
+
+	describe('lastActivity', () => {
+		test('Set user lastActivity', () => {
+			const store = useStore.getState();
+			store.setUserInfo([user1]);
+			store.setUserLastActivity(user1.id, 1234567890);
+
+			expect(useStore.getState().users[user1.id].lastActivity).toBe(1234567890);
+		});
+
+		test('Reset lastActivity', () => {
+			const store = useStore.getState();
+			store.setUserInfo([user1]);
+			store.setUserLastActivity(user1.id);
+
+			expect(useStore.getState().users[user1.id].lastActivity).toBeUndefined();
+		});
+	});
+
+	describe('anonymous user', () => {
+		test('Set anonymous user', () => {
+			const store = useStore.getState();
+			store.setUserInfo([user1]);
+			store.setAnonymousUser(user1.id);
+
+			expect(useStore.getState().users[user1.id].type).toBe(UserType.ANONYMOUS);
+		});
+
+		test('Set anonymous user with lastActivity', () => {
+			const store = useStore.getState();
+			store.setUserInfo([user1]);
+			store.setUserLastActivity(user1.id, 1234567);
+			store.setAnonymousUser(user1.id);
+
+			expect(useStore.getState().users[user1.id].type).toBe(UserType.ANONYMOUS);
+			expect(useStore.getState().users[user1.id].lastActivity).toBe(1234567);
+		});
+	});
+});

--- a/src/store/slices/UsersStoreSlice.ts
+++ b/src/store/slices/UsersStoreSlice.ts
@@ -29,7 +29,7 @@ export const useUsersStoreSlice: StateCreator<
 						id: user.id,
 						email: user.email,
 						name: user.name,
-						type: user.type ?? UserType.INTERNAL
+						type: user.type
 					};
 				});
 			}),
@@ -49,7 +49,7 @@ export const useUsersStoreSlice: StateCreator<
 			'USERS/SET_PRESENCE'
 		);
 	},
-	setUserLastActivity: (id: string, date: number): void => {
+	setUserLastActivity: (id: string, date?: number): void => {
 		set(
 			produce((draft: RootStore) => {
 				draft.users[id] = {

--- a/src/store/slices/UsersStoreSlice.ts
+++ b/src/store/slices/UsersStoreSlice.ts
@@ -55,7 +55,7 @@ export const useUsersStoreSlice: StateCreator<
 			produce((draft: RootStore) => {
 				draft.users[id] = {
 					...draft.users[id],
-					last_activity: date
+					lastActivity: date
 				};
 			}),
 			false,

--- a/src/store/slices/UsersStoreSlice.ts
+++ b/src/store/slices/UsersStoreSlice.ts
@@ -29,8 +29,7 @@ export const useUsersStoreSlice: StateCreator<
 						id: user.id,
 						email: user.email,
 						name: user.name,
-						type: user.type ?? UserType.INTERNAL,
-						lastSeen: user.lastSeen
+						type: user.type ?? UserType.INTERNAL
 					};
 				});
 			}),

--- a/src/store/slices/UsersStoreSlice.ts
+++ b/src/store/slices/UsersStoreSlice.ts
@@ -6,6 +6,7 @@
  */
 
 import { produce } from 'immer';
+import { forEach } from 'lodash';
 import { StateCreator } from 'zustand';
 
 import { UserBe } from '../../types/network/models/userBeTypes';
@@ -19,17 +20,19 @@ export const useUsersStoreSlice: StateCreator<
 	UsersStoreSlice
 > = (set) => ({
 	users: {},
-	setUserInfo: (user: UserBe): void => {
+	setUserInfo: (users: UserBe[]): void => {
 		set(
 			produce((draft: RootStore) => {
-				draft.users[user.id] = {
-					...draft.users[user.id],
-					id: user.id,
-					email: user.email,
-					name: user.name,
-					type: user.type ?? UserType.INTERNAL,
-					lastSeen: user.lastSeen
-				};
+				forEach(users, (user) => {
+					draft.users[user.id] = {
+						...draft.users[user.id],
+						id: user.id,
+						email: user.email,
+						name: user.name,
+						type: user.type ?? UserType.INTERNAL,
+						lastSeen: user.lastSeen
+					};
+				});
 			}),
 			false,
 			'USERS/SET_USER_INFO'

--- a/src/store/slices/UsersStoreSlice.ts
+++ b/src/store/slices/UsersStoreSlice.ts
@@ -9,8 +9,8 @@ import { produce } from 'immer';
 import { StateCreator } from 'zustand';
 
 import { UserBe } from '../../types/network/models/userBeTypes';
-import { RootStore, UsersStoreSlice } from '../../types/store/StoreTypes';
-import { UserType } from '../../types/store/UserTypes';
+import { RootStore } from '../../types/store/StoreTypes';
+import { UsersStoreSlice, UserType } from '../../types/store/UserTypes';
 
 export const useUsersStoreSlice: StateCreator<
 	RootStore,
@@ -28,8 +28,7 @@ export const useUsersStoreSlice: StateCreator<
 					email: user.email,
 					name: user.name,
 					type: user.type ?? UserType.INTERNAL,
-					lastSeen: user.lastSeen,
-					statusMessage: user.statusMessage
+					lastSeen: user.lastSeen
 				};
 			}),
 			false,
@@ -58,18 +57,6 @@ export const useUsersStoreSlice: StateCreator<
 			}),
 			false,
 			'USERS/SET_LAST_ACTIVITY'
-		);
-	},
-	setUserStatusMessage: (id: string, statusMsg: string): void => {
-		set(
-			produce((draft: RootStore) => {
-				draft.users[id] = {
-					...draft.users[id],
-					statusMessage: statusMsg
-				};
-			}),
-			false,
-			'USERS/SET_STATUS_MESSAGE'
 		);
 	},
 	setAnonymousUser: (id: string): void => {

--- a/src/types/network/models/userBeTypes.ts
+++ b/src/types/network/models/userBeTypes.ts
@@ -11,5 +11,4 @@ export type UserBe = {
 	email: string;
 	name: string;
 	type: UserType;
-	lastSeen?: number;
 };

--- a/src/types/network/models/userBeTypes.ts
+++ b/src/types/network/models/userBeTypes.ts
@@ -12,5 +12,4 @@ export type UserBe = {
 	name: string;
 	type: UserType;
 	lastSeen?: number;
-	statusMessage?: string;
 };

--- a/src/types/store/StoreTypes.ts
+++ b/src/types/store/StoreTypes.ts
@@ -32,19 +32,9 @@ import {
 import { RoomsMap } from './RoomTypes';
 import { ExportStatus, Session } from './SessionTypes';
 import { UnreadsMap } from './UnreadsCounterTypes';
-import { UsersMap, UserType } from './UserTypes';
+import { UsersStoreSlice, UserType } from './UserTypes';
 import { MeetingBe } from '../network/models/meetingBeTypes';
 import { MemberBe, RoomBe } from '../network/models/roomBeTypes';
-import { UserBe } from '../network/models/userBeTypes';
-
-export type UsersStoreSlice = {
-	users: UsersMap;
-	setUserInfo: (user: UserBe) => void;
-	setUserPresence: (id: string, presence: boolean) => void;
-	setUserLastActivity: (id: string, date: number) => void;
-	setUserStatusMessage: (id: string, statusMsg: string) => void;
-	setAnonymousUser: (id: string) => void;
-};
 
 export type RoomsStoreSlice = {
 	rooms: RoomsMap;

--- a/src/types/store/UserTypes.ts
+++ b/src/types/store/UserTypes.ts
@@ -19,7 +19,6 @@ export type User = {
 	email: string;
 	name: string;
 	type: UserType;
-	lastSeen?: number;
 	online?: boolean;
 	lastActivity?: number;
 };

--- a/src/types/store/UserTypes.ts
+++ b/src/types/store/UserTypes.ts
@@ -21,7 +21,7 @@ export type User = {
 	type: UserType;
 	lastSeen?: number;
 	online?: boolean;
-	last_activity?: number;
+	lastActivity?: number;
 };
 
 export type UsersMap = {

--- a/src/types/store/UserTypes.ts
+++ b/src/types/store/UserTypes.ts
@@ -8,7 +8,7 @@ import { UserBe } from '../network/models/userBeTypes';
 
 export type UsersStoreSlice = {
 	users: UsersMap;
-	setUserInfo: (user: UserBe) => void;
+	setUserInfo: (users: UserBe[]) => void;
 	setUserPresence: (id: string, presence: boolean) => void;
 	setUserLastActivity: (id: string, date: number) => void;
 	setAnonymousUser: (id: string) => void;

--- a/src/types/store/UserTypes.ts
+++ b/src/types/store/UserTypes.ts
@@ -10,7 +10,7 @@ export type UsersStoreSlice = {
 	users: UsersMap;
 	setUserInfo: (users: UserBe[]) => void;
 	setUserPresence: (id: string, presence: boolean) => void;
-	setUserLastActivity: (id: string, date: number) => void;
+	setUserLastActivity: (id: string, date?: number) => void;
 	setAnonymousUser: (id: string) => void;
 };
 

--- a/src/types/store/UserTypes.ts
+++ b/src/types/store/UserTypes.ts
@@ -4,13 +4,22 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import { UserBe } from '../network/models/userBeTypes';
+
+export type UsersStoreSlice = {
+	users: UsersMap;
+	setUserInfo: (user: UserBe) => void;
+	setUserPresence: (id: string, presence: boolean) => void;
+	setUserLastActivity: (id: string, date: number) => void;
+	setAnonymousUser: (id: string) => void;
+};
+
 export type User = {
 	id: string;
 	email: string;
 	name: string;
 	type: UserType;
 	lastSeen?: number;
-	statusMessage?: string;
 	online?: boolean;
 	last_activity?: number;
 };

--- a/src/utils/UserDataRetriever.test.ts
+++ b/src/utils/UserDataRetriever.test.ts
@@ -71,7 +71,7 @@ describe('UserDataRetriever tests', () => {
 
 	test('If the name is in the store, getAsyncUsername return it', async () => {
 		const spyOnGetUser = spyOnUsersApi(UsersApiToSpy.GET_USER);
-		useStore.getState().setUserInfo(user1);
+		useStore.getState().setUserInfo([user1]);
 		const name = await UserDataRetriever.getAsyncUsername(user1.id);
 		expect(name).toEqual(user1.name);
 		expect(spyOnGetUser).not.toHaveBeenCalled();


### PR DESCRIPTION
Reviewed usage and implementation of `UsersStoreSlice`:
- removed `statusMessages` reference
- refactored `setUserInfo` setter to accept an array of `UserBe` according to the new bulk api
- renamed `last_activity` to `lastActivity`
- removed unused `lastSeen` property from `UserType`
- added missing tests