### PR TITLE
refactor: improve meetings store slice ref: WSC-1934

### DIFF
--- a/src/chats/components/GroupAvatar.test.tsx
+++ b/src/chats/components/GroupAvatar.test.tsx
@@ -67,8 +67,7 @@ const meetingMuted: MeetingBe = createMockMeeting({
 beforeEach(() => {
 	const store = useStore.getState();
 	store.addRooms([room, roomMuted, roomWithMeeting, roomMutedWithMeeting]);
-	store.addMeeting(meeting);
-	store.addMeeting(meetingMuted);
+	store.addMeetings([meeting, meetingMuted]);
 });
 
 describe('Group avatar', () => {

--- a/src/chats/components/GroupAvatar.test.tsx
+++ b/src/chats/components/GroupAvatar.test.tsx
@@ -55,11 +55,13 @@ const roomMutedWithMeeting = createMockRoom({
 });
 
 const meeting: MeetingBe = createMockMeeting({
+	id: 'meetingId',
 	roomId: roomWithMeeting.id,
 	participants: meetingParticipants
 });
 
 const meetingMuted: MeetingBe = createMockMeeting({
+	id: 'meetingMutedId',
 	roomId: roomMutedWithMeeting.id,
 	participants: meetingParticipants
 });

--- a/src/chats/components/UserAvatar.test.tsx
+++ b/src/chats/components/UserAvatar.test.tsx
@@ -117,8 +117,7 @@ beforeEach(() => {
 		roomMuted,
 		roomMutedWithMeeting
 	]);
-	store.addMeeting(meeting);
-	store.addMeeting(meeting2);
+	store.addMeetings([meeting, meeting2]);
 });
 
 describe('User avatar', () => {

--- a/src/chats/components/conversation/MessageHistoryLoader.tsx
+++ b/src/chats/components/conversation/MessageHistoryLoader.tsx
@@ -84,7 +84,7 @@ const MessageHistoryLoader = ({
 	const handleHistoryLoader = useCallback(
 		debounce(() => {
 			const store = useStore.getState();
-			const roomMessages = store.chatsRegistry[roomId].messages;
+			const roomMessages = store.chatsRegistry[roomId]?.messages;
 			const lastMamMessage = store.activeConversations[roomId]?.lastMamMessage;
 			const date = lastMamMessage?.date ?? first(roomMessages)?.date ?? now();
 			if (!historyLoadedDisabled) {

--- a/src/chats/components/infoPanel/conversationActionsAccordion/DeleteConversationModal.test.tsx
+++ b/src/chats/components/infoPanel/conversationActionsAccordion/DeleteConversationModal.test.tsx
@@ -44,7 +44,7 @@ const testMeeting: MeetingBe = createMockMeeting({
 beforeEach(() => {
 	const store = useStore.getState();
 	store.addRooms([testRoom]);
-	store.addMeeting(testMeeting);
+	store.addMeetings([testMeeting]);
 });
 
 describe('Delete Conversation Modal', () => {

--- a/src/chats/components/secondaryBar/virtualRoomWidget/DeleteVirtualRoomModal.test.tsx
+++ b/src/chats/components/secondaryBar/virtualRoomWidget/DeleteVirtualRoomModal.test.tsx
@@ -43,7 +43,7 @@ describe('SelectVirtualRoomWidget', () => {
 			store.setLoginInfo(sessionUser.id, sessionUser.name);
 			store.setAttributes(createMockAttributesList());
 			store.addRooms([temporaryRoomMod]);
-			store.setMeetings([scheduledMeetingMod]);
+			store.addMeetings([scheduledMeetingMod]);
 		});
 		const { user } = setup(
 			<DeleteVirtualRoomModal

--- a/src/chats/components/secondaryBar/virtualRoomWidget/VirtualRoomsButton.test.tsx
+++ b/src/chats/components/secondaryBar/virtualRoomWidget/VirtualRoomsButton.test.tsx
@@ -30,7 +30,7 @@ beforeEach(() => {
 	store.setLoginInfo(sessionUser.id, sessionUser.name);
 	store.setUserInfo([user1]);
 	store.setAttributes(createMockAttributesList({ carbonioWscVideoCallEnabled: 'TRUE' }));
-	store.setMeetings([virtualRoom]);
+	store.addMeetings([virtualRoom]);
 });
 
 describe('VirtualRoomsButton', () => {

--- a/src/chats/components/secondaryBar/virtualRoomWidget/virtualRoomCard/EditVirtualRoomModal.test.tsx
+++ b/src/chats/components/secondaryBar/virtualRoomWidget/virtualRoomCard/EditVirtualRoomModal.test.tsx
@@ -47,7 +47,7 @@ const meeting = createMockMeeting({ roomId: virtualRoom.id });
 beforeEach(() => {
 	const store = useStore.getState();
 	store.addRooms([virtualRoom]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 	store.setUserInfo([member1]);
 	mockSearchUsersByFeatureRequest.mockResolvedValueOnce([user1, user2]);
 });

--- a/src/chats/components/secondaryBar/virtualRoomWidget/virtualRoomCard/EditVirtualRoomModal.tsx
+++ b/src/chats/components/secondaryBar/virtualRoomWidget/virtualRoomCard/EditVirtualRoomModal.tsx
@@ -17,7 +17,7 @@ import { filter, forEach, map, size } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { RoomsApi } from '../../../../../network';
-import { getMeetingParticipants } from '../../../../../store/selectors/MeetingSelectors';
+import { getMeetingParticipantsByRoomId } from '../../../../../store/selectors/MeetingSelectors';
 import { getRoomNameSelector, useOwners } from '../../../../../store/selectors/RoomsSelectors';
 import { getUserId } from '../../../../../store/selectors/SessionSelectors';
 import { getUserEmail, getUserName } from '../../../../../store/selectors/UsersSelectors';
@@ -39,7 +39,7 @@ const EditVirtualRoomModal: FC<deleteVirtualRoomModalProps> = ({
 }) => {
 	const roomName = useStore((state) => getRoomNameSelector(state, roomId));
 	const owners = useOwners(roomId);
-	const meetingParticipants = useStore((state) => getMeetingParticipants(state, roomId));
+	const meetingParticipants = useStore((state) => getMeetingParticipantsByRoomId(state, roomId));
 
 	const [t] = useTranslation();
 	const modalTitle = t('meeting.virtual.modal.edit.title ', `Edit "${roomName}" Virtual Room`, {

--- a/src/chats/components/secondaryBar/virtualRoomWidget/virtualRoomCard/ParticipantsSection.tsx
+++ b/src/chats/components/secondaryBar/virtualRoomWidget/virtualRoomCard/ParticipantsSection.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
 import useAvatarUtilities from '../../../../../hooks/useAvatarUtilities';
-import { getMeetingParticipants } from '../../../../../store/selectors/MeetingSelectors';
+import { getMeetingParticipantsByRoomId } from '../../../../../store/selectors/MeetingSelectors';
 import { getUserName } from '../../../../../store/selectors/UsersSelectors';
 import useStore from '../../../../../store/Store';
 import UserPopoverList from '../../../userPopoverList/UserPopoverList';
@@ -77,7 +77,7 @@ const ParticipantsSection: FC<ParticipantsSectionProp> = ({
 	);
 	const activeParticipantsLabel = t('meeting.virtual.participants.widget', 'Active participants:');
 
-	const meetingParticipants = useStore((store) => getMeetingParticipants(store, roomId));
+	const meetingParticipants = useStore((store) => getMeetingParticipantsByRoomId(store, roomId));
 
 	const firstParticipantId = useMemo(() => {
 		if (meetingParticipants && Object.keys(meetingParticipants).length > 0) {

--- a/src/chats/components/secondaryBar/virtualRoomWidget/virtualRoomCard/VirtualRoomCard.test.tsx
+++ b/src/chats/components/secondaryBar/virtualRoomWidget/virtualRoomCard/VirtualRoomCard.test.tsx
@@ -61,7 +61,7 @@ beforeEach(() => {
 	store.setLoginInfo(sessionUser.id, sessionUser.name);
 	store.setUserInfo([sessionUser, userOne]);
 	store.addRooms([ownerRoom, ownersRoom, memberRoom]);
-	store.setMeetings([ownerMeeting, ownersMeeting, memberMeeting]);
+	store.addMeetings([ownerMeeting, ownersMeeting, memberMeeting]);
 });
 
 describe('VirtualRoomCard', () => {

--- a/src/chats/components/secondaryBar/virtualRoomWidget/virtualRoomCard/VirtualRoomCard.tsx
+++ b/src/chats/components/secondaryBar/virtualRoomWidget/virtualRoomCard/VirtualRoomCard.tsx
@@ -51,7 +51,7 @@ const MeetingActive = styled.div<{ $meetingIsActive?: boolean }>`
 
 const VirtualRoomCard: FC<virtualRoomElementProps> = ({ roomId, modalRef }) => {
 	const room = useStore((state) => getRoomSelector(state, roomId));
-	const meetingIsActive: boolean = useStore((store) => getMeetingActive(store, roomId));
+	const meetingIsActive = useStore((store) => getMeetingActive(store, roomId));
 	const amIParticipating = useStore((state) => getMyMeetingParticipation(state, roomId));
 	const userIsModerator = useStore((store) => getOwnershipOfTheRoom(store, roomId ?? ''));
 

--- a/src/hooks/useGeneralMeetingControls.test.tsx
+++ b/src/hooks/useGeneralMeetingControls.test.tsx
@@ -21,7 +21,7 @@ beforeEach(() => {
 	store.setLoginInfo('userId', 'User');
 	store.setChatsBeStatus(true);
 	store.setWebsocketStatus(true);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 	store.meetingConnection(meeting.id, false, undefined, false, undefined);
 });
 describe('useGeneralMeetingControl hook', () => {

--- a/src/hooks/useGeneralMeetingControls.tsx
+++ b/src/hooks/useGeneralMeetingControls.tsx
@@ -21,7 +21,7 @@ import { MeetingsApi } from '../network';
 import useTiles from './useTiles';
 import {
 	getMeetingActiveByMeetingId,
-	getMeetingParticipantsByMeetingId
+	getMeetingParticipants
 } from '../store/selectors/MeetingSelectors';
 import useStore from '../store/Store';
 import { STREAM_TYPE } from '../types/store/ActiveMeetingTypes';
@@ -41,7 +41,7 @@ const useGeneralMeetingControls = (meetingId: string): void => {
 
 	const isMeetingActive = useStore((store) => getMeetingActiveByMeetingId(store, meetingId));
 	const meetingParticipants: MeetingParticipantMap | undefined = useStore((store) =>
-		getMeetingParticipantsByMeetingId(store, meetingId)
+		getMeetingParticipants(store, meetingId)
 	);
 	const setPinnedTile = useStore((store) => store.setPinnedTile);
 	const meetingConnection = useStore((store) => store.meetingConnection);

--- a/src/hooks/useTiles.tsx
+++ b/src/hooks/useTiles.tsx
@@ -7,15 +7,13 @@ import { useMemo } from 'react';
 
 import { forEach, sortBy } from 'lodash';
 
-import { getMeetingParticipantsByMeetingId } from '../store/selectors/MeetingSelectors';
+import { getMeetingParticipants } from '../store/selectors/MeetingSelectors';
 import useStore from '../store/Store';
 import { STREAM_TYPE, TileData } from '../types/store/ActiveMeetingTypes';
 import { dateToTimestamp } from '../utils/dateUtils';
 
 const useTiles = (meetingId: string): TileData[] => {
-	const meetingParticipants = useStore((store) =>
-		getMeetingParticipantsByMeetingId(store, meetingId)
-	);
+	const meetingParticipants = useStore((store) => getMeetingParticipants(store, meetingId));
 
 	return useMemo(() => {
 		const tiles: TileData[] = [];

--- a/src/hooks/useTilesOrder.test.tsx
+++ b/src/hooks/useTilesOrder.test.tsx
@@ -26,7 +26,7 @@ beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo('0', 'User');
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 	store.meetingConnection(meeting.id, false, undefined, false, undefined);
 });
 

--- a/src/integrations/virtualRoomIntegration/SelectVirtualRoomWidget.test.tsx
+++ b/src/integrations/virtualRoomIntegration/SelectVirtualRoomWidget.test.tsx
@@ -41,7 +41,7 @@ describe('SelectVirtualRoomWidget', () => {
 			store.setLoginInfo(sessionUser.id, sessionUser.name);
 			store.setAttributes(createMockAttributesList());
 			store.addRooms([temporaryRoomMod]);
-			store.setMeetings([scheduledMeetingMod]);
+			store.addMeetings([scheduledMeetingMod]);
 		});
 		await act(async () => {
 			setup(

--- a/src/meetings/components/MeetingNotification.test.tsx
+++ b/src/meetings/components/MeetingNotification.test.tsx
@@ -26,7 +26,7 @@ beforeEach(() => {
 	const store = useStore.getState();
 	store.setUserInfo([user]);
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 });
 
 describe('MeetingNotification', () => {

--- a/src/meetings/components/MeetingNotification.tsx
+++ b/src/meetings/components/MeetingNotification.tsx
@@ -14,7 +14,7 @@ import styled from 'styled-components';
 import useAvatarUtilities from '../../hooks/useAvatarUtilities';
 import useRoomMeeting from '../../hooks/useRoomMeeting';
 import { getXmppClient } from '../../store/selectors/ConnectionSelector';
-import { getMeetingByMeetingId } from '../../store/selectors/MeetingSelectors';
+import { getMeeting } from '../../store/selectors/MeetingSelectors';
 import { getUserName } from '../../store/selectors/UsersSelectors';
 import useStore from '../../store/Store';
 
@@ -49,7 +49,7 @@ const MeetingNotification = ({
 }: MeetingNotificationProps): ReactElement => {
 	const xmppClient = useStore(getXmppClient);
 	const userName: string = useStore((store) => getUserName(store, from));
-	const meeting = useStore((store) => getMeetingByMeetingId(store, meetingId));
+	const meeting = useStore((store) => getMeeting(store, meetingId));
 
 	const [t] = useTranslation();
 	const userIsInvitingYouLabel = (

--- a/src/meetings/components/MeetingNotificationsHandler.test.tsx
+++ b/src/meetings/components/MeetingNotificationsHandler.test.tsx
@@ -40,7 +40,7 @@ const addIncomingMeetingNotification = (room: RoomBe, meeting: MeetingBe): void 
 	const store = useStore.getState();
 	act(() => {
 		store.addRooms([room]);
-		store.addMeeting(meeting);
+		store.addMeetings([meeting]);
 		sendCustomEvent({ name: EventName.INCOMING_MEETING, data: event });
 	});
 };

--- a/src/meetings/components/RecordingInfo.test.tsx
+++ b/src/meetings/components/RecordingInfo.test.tsx
@@ -41,7 +41,7 @@ beforeEach(() => {
 	store.setLoginInfo(user1.id, 'user1');
 	store.setUserInfo([user1, user2]);
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 	store.meetingConnection(meeting.id, false, undefined, false, undefined);
 });
 describe('RecordingInfo tests', () => {

--- a/src/meetings/components/bubblesWrapper/BubblesWrapper.test.tsx
+++ b/src/meetings/components/bubblesWrapper/BubblesWrapper.test.tsx
@@ -66,7 +66,7 @@ const storeBasicActiveMeetingSetup = (): { user: UserEvent; store: RootStore } =
 	store.setLoginInfo(user1.id, user1.name);
 	store.setUserInfo([user1, user2, user3]);
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 	store.meetingConnection(meeting.id, false, undefined, false, undefined);
 	store.setMeetingSidebarStatus(meeting.id, false);
 	const spyUseParams = jest.spyOn(ReactRouter, 'useParams');

--- a/src/meetings/components/cinemaMode/CinemaMode.test.tsx
+++ b/src/meetings/components/cinemaMode/CinemaMode.test.tsx
@@ -54,7 +54,7 @@ const setupBasicGroupMeeting = (): void => {
 	const store: RootStore = useStore.getState();
 	act(() => {
 		store.addRooms([groupRoom]);
-		store.addMeeting(groupMeeting);
+		store.addMeetings([groupMeeting]);
 		store.meetingConnection(groupMeeting.id, false, undefined, false, undefined);
 	});
 	localStorage.setItem('settings', JSON.stringify({ 'settings.appearance_setting.scaling': 100 }));

--- a/src/meetings/components/faceToFaceMode/FaceToFaceMode.test.tsx
+++ b/src/meetings/components/faceToFaceMode/FaceToFaceMode.test.tsx
@@ -47,7 +47,7 @@ const setupBasicGroupMeeting = (): { user: UserEvent; store: RootStore } => {
 	const { result } = renderHook(() => useStore());
 	act(() => {
 		result.current.addRooms([groupRoom]);
-		result.current.addMeeting(groupMeeting);
+		result.current.addMeetings([groupMeeting]);
 		result.current.meetingConnection(groupMeeting.id, false, undefined, false, undefined);
 	});
 	const spyUseParams = jest.spyOn(ReactRouter, 'useParams');

--- a/src/meetings/components/headerMeetingButton/ActiveMeetingParticipantsDropdown.test.tsx
+++ b/src/meetings/components/headerMeetingButton/ActiveMeetingParticipantsDropdown.test.tsx
@@ -52,7 +52,7 @@ beforeEach(() => {
 	store.setLoginInfo(user1.id, user1.name);
 	store.setUserInfo([user1, user2, user3]);
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 	store.startMeeting(meeting.id, '2024-08-25T17:24:28.961+02:00');
 	store.meetingConnection(meeting.id, false, undefined, false, undefined);
 	const spyUseParams = jest.spyOn(ReactRouter, 'useParams');

--- a/src/meetings/components/headerMeetingButton/ActiveMeetingParticipantsDropdown.tsx
+++ b/src/meetings/components/headerMeetingButton/ActiveMeetingParticipantsDropdown.tsx
@@ -13,7 +13,7 @@ import styled from 'styled-components';
 
 import ParticipantElement from './ParticipantElement';
 import {
-	getMeetingParticipants,
+	getMeetingParticipantsByRoomId,
 	getNumberOfMeetingParticipants
 } from '../../../store/selectors/MeetingSelectors';
 import { getMeetingIdFromRoom } from '../../../store/selectors/RoomsSelectors';
@@ -49,7 +49,7 @@ const ActiveMeetingParticipantsDropdown = ({
 
 	const numberOfParticipants = useStore((store) => getNumberOfMeetingParticipants(store, roomId));
 	const meetingParticipants: MeetingParticipantMap | undefined = useStore((store) =>
-		getMeetingParticipants(store, roomId)
+		getMeetingParticipantsByRoomId(store, roomId)
 	);
 	const meetingId = useStore((store) => getMeetingIdFromRoom(store, roomId));
 

--- a/src/meetings/components/headerMeetingButton/ConversationHeaderMeetingButton.test.tsx
+++ b/src/meetings/components/headerMeetingButton/ConversationHeaderMeetingButton.test.tsx
@@ -89,7 +89,7 @@ describe('Conversation header meeting button - one to one', () => {
 	});
 
 	test('everything is rendered correctly - meeting started', () => {
-		useStore.getState().addMeeting(meetingOneToOne);
+		useStore.getState().addMeetings([meetingOneToOne]);
 		setup(<ConversationHeaderMeetingButton roomId={oneToOneRoom.id} />);
 		const disabledButton = screen.getByTestId('join_meeting_button');
 		expect(disabledButton).toBeEnabled();
@@ -115,7 +115,7 @@ describe('Conversation header meeting button - group', () => {
 	});
 
 	test('everything is rendered correctly - meeting started', () => {
-		useStore.getState().addMeeting(groupMeeting);
+		useStore.getState().addMeetings([groupMeeting]);
 		setup(<ConversationHeaderMeetingButton roomId={groupRoom.id} />);
 		const disabledButton = screen.getByTestId('join_meeting_button');
 		expect(disabledButton).toBeEnabled();
@@ -126,7 +126,7 @@ describe('Conversation header meeting button - group', () => {
 	});
 
 	test("toggle dropdown - I'm inside the meeting", async () => {
-		useStore.getState().addMeeting(groupMeeting);
+		useStore.getState().addMeetings([groupMeeting]);
 		const { user } = setup(<ConversationHeaderMeetingButton roomId={groupRoom.id} />);
 
 		const participantListButton = screen.getByTestId('participant_list_button');
@@ -142,7 +142,7 @@ describe('Conversation header meeting button - group', () => {
 
 	test("toggle dropdown - I'm not inside the meeting", async () => {
 		const store = useStore.getState();
-		store.addMeeting(groupMeeting);
+		store.addMeetings([groupMeeting]);
 		store.removeParticipant(groupMeeting.id, user1.id);
 		const { user } = setup(<ConversationHeaderMeetingButton roomId={groupRoom.id} />);
 
@@ -162,7 +162,7 @@ describe('Conversation header meeting button - group', () => {
 	});
 
 	test('go to private chat from dropdown', async () => {
-		useStore.getState().addMeeting(groupMeeting);
+		useStore.getState().addMeetings([groupMeeting]);
 		const { user } = setup(<ConversationHeaderMeetingButton roomId={groupRoom.id} />);
 
 		const participantListButton = screen.getByTestId('participant_list_button');
@@ -178,7 +178,7 @@ describe('Conversation header meeting button - group', () => {
 	test('open meeting', async () => {
 		const meetingOpen = jest.spyOn(window, 'open');
 		const store = useStore.getState();
-		store.addMeeting(groupMeeting);
+		store.addMeetings([groupMeeting]);
 		store.removeParticipant(groupMeeting.id, user1.id);
 		const { user } = setup(<ConversationHeaderMeetingButton roomId={groupRoom.id} />);
 		const joinMeetingButton = screen.getByTestId('join_meeting_button');
@@ -191,7 +191,7 @@ describe('Conversation header meeting button - group', () => {
 
 	test("hide dropdown when there's no one else inside the meeting", async () => {
 		const store = useStore.getState();
-		store.addMeeting(groupMeeting);
+		store.addMeetings([groupMeeting]);
 		store.removeParticipant(groupMeeting.id, user1.id);
 		const { user } = setup(<ConversationHeaderMeetingButton roomId={groupRoom.id} />);
 		const participantListButton = screen.getByTestId('participant_list_button');

--- a/src/meetings/components/headerMeetingButton/ParticipantElement.test.tsx
+++ b/src/meetings/components/headerMeetingButton/ParticipantElement.test.tsx
@@ -21,7 +21,7 @@ const activeMeeting = createMockMeeting({});
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.addMeeting(activeMeeting);
+	store.addMeetings([activeMeeting]);
 	store.setLoginInfo(loggedUser.id, loggedUser.name, loggedUser.type);
 });
 

--- a/src/meetings/components/meetingAccessPoint/MeetingAccessPageMediaSection.test.tsx
+++ b/src/meetings/components/meetingAccessPoint/MeetingAccessPageMediaSection.test.tsx
@@ -53,7 +53,7 @@ beforeEach(() => {
 	store.setUserInfo([user1, user2]);
 	store.setLoginInfo(user1.id, user1.name);
 	store.addRooms([groupRoom]);
-	store.addMeeting(groupMeeting);
+	store.addMeetings([groupMeeting]);
 	store.setChatsBeStatus(true);
 	store.setWebsocketStatus(true);
 	store.meetingConnection(groupMeeting.id, false, undefined, false, undefined);

--- a/src/meetings/components/meetingAccessPoint/MeetingAccessPageMediaSection.tsx
+++ b/src/meetings/components/meetingAccessPoint/MeetingAccessPageMediaSection.tsx
@@ -31,7 +31,7 @@ import LocalMediaHandler from './mediaHandlers/LocalMediaHandler';
 import { MEETINGS_PATH } from '../../../constants/appConstants';
 import useEventListener, { EventName } from '../../../hooks/useEventListener';
 import useLocalStorage from '../../../hooks/useLocalStorage';
-import { getRoomIdFromMeeting } from '../../../store/selectors/MeetingSelectors';
+import { getRoomIdByMeetingId } from '../../../store/selectors/MeetingSelectors';
 import { getRoomNameSelector } from '../../../store/selectors/RoomsSelectors';
 import useStore from '../../../store/Store';
 import { LOCAL_STORAGE_NAMES, MeetingStorageType } from '../../../utils/localStorageUtils';
@@ -80,7 +80,7 @@ const MeetingAccessPageMediaSection: FC<AccessMeetingPageMediaSectionProps> = ({
 }) => {
 	const [t] = useTranslation();
 	const meetingId = useMemo(() => document.location.pathname.split(MEETINGS_PATH)[1], []);
-	const roomId = useStore((store) => getRoomIdFromMeeting(store, meetingId) ?? ``);
+	const roomId = useStore((store) => getRoomIdByMeetingId(store, meetingId) ?? ``);
 	const conversationTitle = useStore((store) => getRoomNameSelector(store, roomId));
 
 	const playMicLabel = t('meeting.interactions.playMic', 'Start mic test');

--- a/src/meetings/components/meetingAccessPoint/useAccessMeetingAction.tsx
+++ b/src/meetings/components/meetingAccessPoint/useAccessMeetingAction.tsx
@@ -11,7 +11,7 @@ import useDarkReader from '../../../hooks/useDarkReader';
 import useEventListener, { EventName } from '../../../hooks/useEventListener';
 import useRouting from '../../../hooks/useRouting';
 import { MeetingsApi } from '../../../network';
-import { getRoomIdFromMeeting } from '../../../store/selectors/MeetingSelectors';
+import { getRoomIdByMeetingId } from '../../../store/selectors/MeetingSelectors';
 import { getIsLoggedUserExternal } from '../../../store/selectors/SessionSelectors';
 import useStore from '../../../store/Store';
 import { BrowserUtils } from '../../../utils/BrowserUtils';
@@ -90,8 +90,9 @@ const useAccessMeetingAction = (
 			mediaDevicesEnabled?: { audio: boolean; video: boolean },
 			selectedDevicesId?: { audio?: string; video?: string }
 		) => {
+			const roomId = getRoomIdByMeetingId(useStore.getState(), meetingId) ?? '';
 			MeetingsApi.enterMeeting(
-				getRoomIdFromMeeting(useStore.getState(), meetingId) ?? '',
+				roomId,
 				{
 					videoStreamEnabled: mediaDevicesEnabled ? mediaDevicesEnabled.video : false,
 					audioStreamEnabled: mediaDevicesEnabled ? mediaDevicesEnabled.audio : false

--- a/src/meetings/components/meetingAccessPoint/useAccessMeetingInformation.tsx
+++ b/src/meetings/components/meetingAccessPoint/useAccessMeetingInformation.tsx
@@ -21,7 +21,7 @@ import { useTranslation } from 'react-i18next';
 import { MEETINGS_PATH } from '../../../constants/appConstants';
 import useRouting from '../../../hooks/useRouting';
 import { MeetingsApi } from '../../../network';
-import { getRoomIdFromMeeting } from '../../../store/selectors/MeetingSelectors';
+import { getRoomIdByMeetingId } from '../../../store/selectors/MeetingSelectors';
 import { getRoomNameSelector, getRoomTypeSelector } from '../../../store/selectors/RoomsSelectors';
 import useStore from '../../../store/Store';
 import { MeetingType } from '../../../types/network/models/meetingBeTypes';
@@ -45,7 +45,7 @@ const useAccessMeetingInformation = (): UseAccessMeetingInformationReturnType =>
 	const [userIsReady, setUserIsReady] = useState<boolean>(false);
 
 	const meetingId = useMemo(() => document.location.pathname.split(MEETINGS_PATH)[1], []);
-	const roomId = useStore((store) => getRoomIdFromMeeting(store, meetingId) ?? ``);
+	const roomId = useStore((store) => getRoomIdByMeetingId(store, meetingId) ?? ``);
 	const conversationTitle = useStore((store) => getRoomNameSelector(store, roomId));
 	const roomType = useStore((store) => getRoomTypeSelector(store, roomId));
 

--- a/src/meetings/components/meetingActionsBar/CameraButtonPermissionDenied.test.tsx
+++ b/src/meetings/components/meetingActionsBar/CameraButtonPermissionDenied.test.tsx
@@ -68,7 +68,7 @@ beforeEach(() => {
 	store.setUserInfo([user1, user2]);
 	store.setLoginInfo(user1.id, user1.name);
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 	store.meetingConnection(meeting.id, false, undefined, false, undefined);
 });
 describe('Camera button - permission denied', () => {

--- a/src/meetings/components/meetingActionsBar/MeetingActionsBar.test.tsx
+++ b/src/meetings/components/meetingActionsBar/MeetingActionsBar.test.tsx
@@ -59,7 +59,7 @@ beforeEach(() => {
 	store.setLoginInfo(user1.id, user1.name);
 	store.setUserInfo([user1, user2, user3]);
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 	store.startMeeting(meeting.id, '2024-08-25T17:24:28.961+02:00');
 	store.meetingConnection(meeting.id, false, undefined, false, undefined);
 	store.setAttributes(createMockAttributesList());

--- a/src/meetings/components/meetingActionsBar/MeetingDuration.test.tsx
+++ b/src/meetings/components/meetingActionsBar/MeetingDuration.test.tsx
@@ -24,7 +24,7 @@ const meeting: MeetingBe = createMockMeeting({
 beforeEach(() => {
 	const store: RootStore = useStore.getState();
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 	store.startMeeting(meeting.id, '2024-08-25T17:24:28.961+02:00');
 });
 describe('MeetingDuration tests', () => {

--- a/src/meetings/components/meetingActionsBar/MoreActionsButton.test.tsx
+++ b/src/meetings/components/meetingActionsBar/MoreActionsButton.test.tsx
@@ -72,7 +72,7 @@ const storeSetupGroupMeeting = (): { user: UserEvent; store: RootStore } => {
 	store.setUserInfo([user1, user2, user3]);
 	store.setLoginInfo(user1.id, user1.name);
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 	store.meetingConnection(meeting.id, false, undefined, false, undefined);
 
 	const spyUseParams = jest.spyOn(ReactRouter, 'useParams');
@@ -88,7 +88,7 @@ const storeSetupGroupMeetingWithOnePerson = (): { user: UserEvent } => {
 		result.current.setUserInfo([user1]);
 		result.current.setLoginInfo(user1.id, user1.name);
 		result.current.addRooms([room]);
-		result.current.addMeeting(meetingWithOnePerson);
+		result.current.addMeetings([meetingWithOnePerson]);
 		result.current.meetingConnection(meetingWithOnePerson.id, false, undefined, false, undefined);
 	});
 	const spyUseParams = jest.spyOn(ReactRouter, 'useParams');
@@ -110,7 +110,7 @@ const storeSetupGroupMeetingPip = (): { user: UserEvent; store: RootStore } => {
 	store.setUserInfo([user1, user2, user3]);
 	store.setLoginInfo(user1.id, user1.name);
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 	store.meetingConnection(meeting.id, false, undefined, false, undefined);
 	store.setLocalStreams(meeting.id, STREAM_TYPE.VIDEO, new MediaStream());
 	store.setAttributes(createMockAttributesList());

--- a/src/meetings/components/meetingActionsBar/RaiseHandButton.test.tsx
+++ b/src/meetings/components/meetingActionsBar/RaiseHandButton.test.tsx
@@ -60,7 +60,7 @@ const storeSetupGroupMeeting = (): { user: UserEvent; store: RootStore } => {
 	store.setUserInfo([user1, user2, user3]);
 	store.setLoginInfo(user1.id, user1.name);
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 	store.meetingConnection(meeting.id, false, undefined, false, undefined);
 	const spyUseParams = jest.spyOn(ReactRouter, 'useParams');
 	spyUseParams.mockReturnValue({ meetingId: meeting.id });

--- a/src/meetings/components/meetingActionsBar/ScreenShareButton.test.tsx
+++ b/src/meetings/components/meetingActionsBar/ScreenShareButton.test.tsx
@@ -40,12 +40,12 @@ describe('ScreenShare button', () => {
 		const store = useStore.getState();
 		store.setWebsocketStatus(true);
 		store.setLoginInfo('userId', 'User', 'User');
-		store.addMeeting(
+		store.addMeetings([
 			createMockMeeting({
 				id: meeting.id,
 				participants: [createMockParticipants({ userId: 'userId', screenStreamEnabled: false })]
 			})
-		);
+		]);
 		setup(<ScreenShareButton />);
 		const disabledScreenShareIcon = await screen.findByTestId('icon: ScreenSharingOff');
 		expect(disabledScreenShareIcon).toBeVisible();
@@ -55,12 +55,12 @@ describe('ScreenShare button', () => {
 		const store = useStore.getState();
 		store.setWebsocketStatus(true);
 		store.setLoginInfo('userId', 'User', 'User');
-		store.addMeeting(
+		store.addMeetings([
 			createMockMeeting({
 				id: meeting.id,
 				participants: [createMockParticipants({ userId: 'userId', screenStreamEnabled: true })]
 			})
-		);
+		]);
 		routerContextSetup(<ScreenShareButton />, {
 			meetingId: meeting.id,
 			route: MEETINGS_ROUTES.MEETING

--- a/src/meetings/components/mobile/MobileActionBar.test.tsx
+++ b/src/meetings/components/mobile/MobileActionBar.test.tsx
@@ -76,7 +76,7 @@ describe('MobileActionBar test', () => {
 		);
 		const store = useStore.getState();
 		store.setLoginInfo('userId', 'User');
-		store.addMeeting(mockMeeting);
+		store.addMeetings([mockMeeting]);
 		store.addParticipant(mockMeeting.id, {
 			userId: 'userId',
 			audioStreamOn: false,

--- a/src/meetings/components/pictureInPicture/PictureInPictureView.test.tsx
+++ b/src/meetings/components/pictureInPicture/PictureInPictureView.test.tsx
@@ -60,7 +60,7 @@ const storeSetupGroupMeetingPip = (): { user: UserEvent; store: RootStore } => {
 	store.setUserInfo([user1, user2, user3]);
 	store.setLoginInfo(user1.id, user1.name);
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 	store.meetingConnection(meeting.id, false, undefined, false, undefined);
 	store.setLocalStreams(meeting.id, STREAM_TYPE.VIDEO, new MediaStream());
 	store.setAttributes(createMockAttributesList());

--- a/src/meetings/components/pictureInPicture/PictureInPictureView.tsx
+++ b/src/meetings/components/pictureInPicture/PictureInPictureView.tsx
@@ -18,7 +18,7 @@ import {
 	getSelectedVideoDeviceId
 } from '../../../store/selectors/ActiveMeetingSelectors';
 import {
-	getMeetingByMeetingId,
+	getMeeting,
 	getParticipantAudioStatus,
 	getParticipantVideoStatus
 } from '../../../store/selectors/MeetingSelectors';
@@ -53,7 +53,7 @@ const PictureInPictureView = (): ReactElement => {
 	const noOneTalking = t('meeting.pip.noTalking', "Nobody's talking right now.");
 
 	const myUserId = useStore(getUserId);
-	const meeting = useStore((store) => getMeetingByMeetingId(store, meetingId!));
+	const meeting = useStore((store) => getMeeting(store, meetingId!));
 	const whoIsSpeaking = useStore((store) => getNameOfFirstTalkingUser(store, meetingId!));
 	const videoOutConn = useStore((store) => store.activeMeeting[meetingId!]?.videoOutConn);
 	const videoStatus = useStore((store) => getParticipantVideoStatus(store, meetingId, myUserId));

--- a/src/meetings/components/sidebar/MeetingConversationAccordion/MeetingConversationAccordion.test.tsx
+++ b/src/meetings/components/sidebar/MeetingConversationAccordion/MeetingConversationAccordion.test.tsx
@@ -69,7 +69,7 @@ const setupBasicGroup = (): { user: UserEvent; store: RootStore } => {
 		result.current.setLoginInfo(mockUser1.id, mockUser1.name);
 		result.current.setUserInfo([mockUser2]);
 		result.current.addRooms([groupRoom]);
-		result.current.addMeeting(groupMeeting);
+		result.current.addMeetings([groupMeeting]);
 		result.current.meetingConnection(groupMeeting.id, false, undefined, false, undefined);
 	});
 	const { user } = routerContextSetup(<MeetingSidebar />, { meetingId: groupMeeting.id });

--- a/src/meetings/components/sidebar/MeetingSidebar.test.tsx
+++ b/src/meetings/components/sidebar/MeetingSidebar.test.tsx
@@ -97,7 +97,7 @@ beforeEach(() => {
 	store.setLoginInfo(sessionUser.id, sessionUser.name);
 	store.setAttributes(createMockAttributesList({ carbonioWscRecordingEnabled: 'TRUE' }));
 	store.addRooms([oneToOneRoom, groupRoom, temporaryRoom, temporaryRoomMod]);
-	store.setMeetings([oneToOneMeeting, groupMeeting, scheduledMeeting, scheduledMeetingMod]);
+	store.addMeetings([oneToOneMeeting, groupMeeting, scheduledMeeting, scheduledMeetingMod]);
 	store.meetingConnection(oneToOneMeeting.id, false, 'audioId', false, 'videoId');
 	store.setWaitingList(scheduledMeetingMod.id, [user1.id]);
 });

--- a/src/meetings/components/sidebar/ParticipantsAccordion/MeetingParticipantsAccordion.test.tsx
+++ b/src/meetings/components/sidebar/ParticipantsAccordion/MeetingParticipantsAccordion.test.tsx
@@ -60,7 +60,7 @@ const storeSetupGroupMeetingModerator = (): { user: UserEvent; store: RootStore 
 		roomId: room.id,
 		participants: [user1Participant, user2Participant, user3Participant]
 	});
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 	const { user } = setup(<MeetingParticipantsAccordion meetingId={meeting.id} />);
 	return { user, store };
 };
@@ -87,7 +87,7 @@ const storeSetupParticipantModerator = (): {
 		roomId: room.id,
 		participants: [user1Participant, user2Participant]
 	});
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 	store.meetingConnection(meeting.id, false, undefined, false, undefined);
 
 	const { user } = setup(<MeetingParticipantsList meetingId={meeting.id} />);

--- a/src/meetings/components/sidebar/ParticipantsAccordion/MeetingParticipantsList.tsx
+++ b/src/meetings/components/sidebar/ParticipantsAccordion/MeetingParticipantsList.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
 import SearchUserAction from '../../../../chats/components/infoPanel/conversationParticipantsAccordion/SearchUserAction';
-import { getMeetingParticipantsByMeetingId } from '../../../../store/selectors/MeetingSelectors';
+import { getMeetingParticipants } from '../../../../store/selectors/MeetingSelectors';
 import { getUsersSelector } from '../../../../store/selectors/UsersSelectors';
 import useStore from '../../../../store/Store';
 import { MeetingParticipant, MeetingParticipantMap } from '../../../../types/store/MeetingTypes';
@@ -37,7 +37,7 @@ const MeetingParticipantsList: FC<ParticipantsListProps> = ({ meetingId }) => {
 		'Your search returned no results, try another keyword.'
 	);
 	const meetingParticipants: MeetingParticipantMap | undefined = useStore((store) =>
-		getMeetingParticipantsByMeetingId(store, meetingId)
+		getMeetingParticipants(store, meetingId)
 	);
 	const users: UsersMap = useStore(getUsersSelector);
 	const [filteredContactList, setFilteredContactList] = useState<MeetingParticipant[] | undefined>(

--- a/src/meetings/components/sidebar/raiseHandAccordion/RaiseHandAccordion.test.tsx
+++ b/src/meetings/components/sidebar/raiseHandAccordion/RaiseHandAccordion.test.tsx
@@ -45,7 +45,7 @@ beforeEach(() => {
 	store.setLoginInfo(user1.id, 'user1');
 	store.setUserInfo([user1, user2]);
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 	store.meetingConnection(meeting.id, false, undefined, false, undefined);
 	store.setRaiseHandAccordionStatus(meeting.id, true); // default open
 });

--- a/src/meetings/components/sidebar/recordingAccordion/RecordingAccordion.test.tsx
+++ b/src/meetings/components/sidebar/recordingAccordion/RecordingAccordion.test.tsx
@@ -41,7 +41,7 @@ beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo(user1.id, 'user1');
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 	store.meetingConnection(meeting.id, false, undefined, false, undefined);
 });
 

--- a/src/meetings/components/sidebar/recordingAccordion/StopRecordingModal.test.tsx
+++ b/src/meetings/components/sidebar/recordingAccordion/StopRecordingModal.test.tsx
@@ -39,7 +39,7 @@ beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo(user1.id, 'user1');
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 	store.meetingConnection(meeting.id, false, undefined, false, undefined);
 });
 describe('StopRecordingModal tests', () => {

--- a/src/meetings/components/sidebar/waitingListAccordion/WaitingListAccordion.test.tsx
+++ b/src/meetings/components/sidebar/waitingListAccordion/WaitingListAccordion.test.tsx
@@ -38,7 +38,7 @@ beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo(user1.id, 'user1');
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 	store.meetingConnection(meeting.id, false, undefined, false, undefined);
 });
 describe('WaitingListAccordion tests', () => {

--- a/src/meetings/components/tile/Tile.test.tsx
+++ b/src/meetings/components/tile/Tile.test.tsx
@@ -123,7 +123,7 @@ beforeEach(() => {
 	store.setUserInfo([user1, user2, user3]);
 	store.setLoginInfo(user1.id, user1.name);
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 });
 
 describe('Tile test - enter meeting modal', () => {

--- a/src/meetings/components/whoIsSpeaking/WhoIsSpeaking.test.tsx
+++ b/src/meetings/components/whoIsSpeaking/WhoIsSpeaking.test.tsx
@@ -59,7 +59,7 @@ beforeEach(() => {
 	store.setUserInfo([user1, user2, user3]);
 	store.setLoginInfo(user1.id, user1.name);
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 	store.meetingConnection(meeting.id, false, undefined, false, undefined);
 	store.setTalkingUser(meeting.id, user3.id, true);
 	store.setTalkingUser(meeting.id, user2.id, true);

--- a/src/meetings/views/AccessPage.test.tsx
+++ b/src/meetings/views/AccessPage.test.tsx
@@ -70,7 +70,7 @@ const setupGroupForAccessPage = (): { user: UserEvent; store: RootStore } => {
 		result.current.setUserInfo([user1, user2, user3]);
 		result.current.setLoginInfo(user3.id, user3.name);
 		result.current.addRooms([groupRoom]);
-		result.current.addMeeting(groupMeeting);
+		result.current.addMeetings([groupMeeting]);
 		result.current.setChatsBeStatus(true);
 		result.current.setWebsocketStatus(true);
 		result.current.meetingConnection(groupMeeting.id, false, undefined, false, undefined);
@@ -87,7 +87,7 @@ const setupAccessPage = (): { user: UserEvent; store: RootStore } => {
 		result.current.setUserInfo([user2, user3]);
 		result.current.setLoginInfo(user2.id, user2.name);
 		result.current.addRooms([groupForWaitingRoom]);
-		result.current.addMeeting(meetingForWaitingRoom);
+		result.current.addMeetings([meetingForWaitingRoom]);
 		result.current.setChatsBeStatus(true);
 		result.current.setWebsocketStatus(true);
 		result.current.meetingConnection(groupMeeting.id, false, undefined, false, undefined);

--- a/src/meetings/views/MeetingSkeleton.test.tsx
+++ b/src/meetings/views/MeetingSkeleton.test.tsx
@@ -67,7 +67,7 @@ const storeSetupGroupMeetingSkeleton = (): { user: UserEvent; store: RootStore }
 	store.setUserInfo([user1, user2, user3]);
 	store.setLoginInfo(user1.id, user1.name);
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 	store.meetingConnection(meeting.id, false, undefined, true, 'videoId');
 	store.setLocalStreams(meeting.id, STREAM_TYPE.VIDEO, new MediaStream());
 	store.setAttributes(createMockAttributesList());

--- a/src/meetings/views/mobile/MeetingSkeletonMobile.test.tsx
+++ b/src/meetings/views/mobile/MeetingSkeletonMobile.test.tsx
@@ -32,7 +32,7 @@ describe('MeetingSkeletonMobile test', () => {
 	test('Conversation view', async () => {
 		const store = useStore.getState();
 		store.addRooms([room]);
-		store.addMeeting(meeting);
+		store.addMeetings([meeting]);
 		const { user } = routerContextSetup(
 			<PiPProvider>
 				<MeetingSkeletonMobile />
@@ -50,7 +50,7 @@ describe('MeetingSkeletonMobile test', () => {
 	test('Participants view', async () => {
 		const store = useStore.getState();
 		store.addRooms([room]);
-		store.addMeeting(meeting);
+		store.addMeetings([meeting]);
 		const { user } = routerContextSetup(
 			<PiPProvider>
 				<MeetingSkeletonMobile />

--- a/src/network/apis/MeetingsApi.test.ts
+++ b/src/network/apis/MeetingsApi.test.ts
@@ -64,9 +64,8 @@ describe('Meetings API', () => {
 		// Check if store is correctly updated
 		const store = useStore.getState();
 		expect(size(store.meetings)).toEqual(2);
-		expect(store.meetings[meetingMock.roomId].id).toEqual(meetingMock.id);
-		expect(store.meetings[meetingMock.roomId].id).toEqual(meetingMock.id);
-		expect(size(store.meetings[meetingMock.roomId].participants)).toEqual(
+		expect(store.meetings[meetingMock.id]).toBeDefined();
+		expect(size(store.meetings[meetingMock.id].participants)).toEqual(
 			size(meetingMock.participants)
 		);
 	});

--- a/src/network/apis/MeetingsApi.test.ts
+++ b/src/network/apis/MeetingsApi.test.ts
@@ -37,7 +37,7 @@ const userId = 'userId';
 
 const ongoingMeetingSetup = (): void => {
 	const store = useStore.getState();
-	store.addMeeting(meetingMock);
+	store.addMeetings([meetingMock]);
 	store.addParticipant(meetingMock.id, {
 		userId: 'userId',
 		audioStreamOn: false,
@@ -152,7 +152,7 @@ describe('Meetings API', () => {
 	});
 
 	test('enterMeeting is called correctly when a meeting is already present and active', async () => {
-		useStore.getState().addMeeting(meetingMock);
+		useStore.getState().addMeetings([meetingMock]);
 		await meetingsApi.enterMeeting(
 			meetingMock.roomId,
 			{
@@ -169,7 +169,7 @@ describe('Meetings API', () => {
 	});
 
 	test('enterMeeting is called correctly when a meeting is already present but not active', async () => {
-		useStore.getState().addMeeting(meetingNotActiveMock);
+		useStore.getState().addMeetings([meetingNotActiveMock]);
 		await meetingsApi.enterMeeting(
 			meetingNotActiveMock.roomId,
 			{

--- a/src/network/apis/MeetingsApi.ts
+++ b/src/network/apis/MeetingsApi.ts
@@ -6,6 +6,7 @@
 
 import { chain, find } from 'lodash';
 
+import { getMeetingByRoomId } from '../../store/selectors/MeetingSelectors';
 import useStore from '../../store/Store';
 import { RequestType } from '../../types/network/apis/IBaseAPI';
 import IMeetingsApi from '../../types/network/apis/IMeetingsApi';
@@ -140,7 +141,7 @@ class MeetingsApi implements IMeetingsApi {
 		settings: JoinSettings,
 		devicesId: { audioDevice?: string; videoDevice?: string }
 	): Promise<string> {
-		const meeting = useStore.getState().meetings[roomId];
+		const meeting = getMeetingByRoomId(useStore.getState(), roomId);
 		if (meeting) {
 			if (meeting.active) {
 				return this.joinMeeting(meeting.id, settings, devicesId).then(() => meeting.id);

--- a/src/network/apis/MeetingsApi.ts
+++ b/src/network/apis/MeetingsApi.ts
@@ -58,8 +58,8 @@ class MeetingsApi implements IMeetingsApi {
 
 	public listMeetings(): Promise<ListMeetingsResponse> {
 		return fetchAPI(`meetings`, RequestType.GET).then((resp: ListMeetingsResponse) => {
-			const { setMeetings } = useStore.getState();
-			setMeetings(resp);
+			const { addMeetings } = useStore.getState();
+			addMeetings(resp);
 			return resp;
 		});
 	}
@@ -85,8 +85,8 @@ class MeetingsApi implements IMeetingsApi {
 
 	public getMeetingByMeetingId(meetingId: string): Promise<GetMeetingResponse> {
 		return fetchAPI(`meetings/${meetingId}`, RequestType.GET).then((resp: GetMeetingResponse) => {
-			const { addMeeting } = useStore.getState();
-			addMeeting(resp);
+			const { addMeetings } = useStore.getState();
+			addMeetings([resp]);
 			return resp;
 		});
 	}

--- a/src/network/apis/RoomsApi.test.ts
+++ b/src/network/apis/RoomsApi.test.ts
@@ -99,7 +99,7 @@ describe('Rooms API', () => {
 	test('deleteRoomAndMeeting with an associated meeting is called correctly', async () => {
 		const room = createMockRoom();
 		const meeting = createMockMeeting({ roomId: room.id });
-		useStore.getState().addMeeting(meeting);
+		useStore.getState().addMeetings([meeting]);
 		// Send deleteRoom request
 		await roomsApi.deleteRoomAndMeeting(room.id);
 

--- a/src/network/webRTC/SubscriptionsManager.test.ts
+++ b/src/network/webRTC/SubscriptionsManager.test.ts
@@ -89,7 +89,7 @@ beforeEach(() => {
 		const store = useStore.getState();
 		store.setLoginInfo(user1Info.id, user1Info.email, user1Info.name);
 		store.addRooms([groupRoom]);
-		store.addMeeting(groupMeeting);
+		store.addMeetings([groupMeeting]);
 		store.meetingConnection(groupMeeting.id, false, undefined, false, undefined);
 	});
 });

--- a/src/network/websocket/eventHandlersUtilities.test.ts
+++ b/src/network/websocket/eventHandlersUtilities.test.ts
@@ -96,8 +96,7 @@ describe('eventHandlersUtilities tests', () => {
 	beforeEach(() => {
 		const store = useStore.getState();
 		store.addRooms([room, activeRoom]);
-		store.addMeeting(meeting);
-		store.addMeeting(activeMeeting);
+		store.addMeetings([meeting, activeMeeting]);
 		store.meetingConnection(activeMeeting.id, false, undefined, false, undefined);
 	});
 	describe('isMeetingActive tests', () => {

--- a/src/network/websocket/wsConversationEventsHandler.test.ts
+++ b/src/network/websocket/wsConversationEventsHandler.test.ts
@@ -8,6 +8,7 @@ import { waitFor } from '@testing-library/react';
 
 import { wsConversationEventsHandler } from './wsConversationEventsHandler';
 import { wsEventsHandler } from './wsEventsHandler';
+import { getMeetingByRoomId } from '../../store/selectors/MeetingSelectors';
 import useStore from '../../store/Store';
 import { createMockMeeting, createMockRoom, createMockUser } from '../../tests/createMock';
 import {
@@ -57,7 +58,8 @@ describe('wsConversationEventHandler tests', () => {
 			sentDate: '2023-01-01T00:00:00.000Z'
 		} as RoomMemberAddedEvent);
 		await waitFor(() => {
-			expect(useStore.getState().meetings[room.id]).toBeDefined();
+			const meeting = getMeetingByRoomId(useStore.getState(), room.id);
+			expect(meeting).toBeDefined();
 		});
 	});
 
@@ -70,7 +72,8 @@ describe('wsConversationEventHandler tests', () => {
 			userId: sessionUser.id
 		} as RoomMemberRemovedEvent);
 		await waitFor(() => {
-			expect(useStore.getState().meetings[room.id]).toBeUndefined();
+			const meeting = getMeetingByRoomId(useStore.getState(), room.id);
+			expect(meeting).toBeUndefined();
 		});
 	});
 });

--- a/src/network/websocket/wsConversationEventsHandler.test.ts
+++ b/src/network/websocket/wsConversationEventsHandler.test.ts
@@ -62,7 +62,7 @@ describe('wsConversationEventHandler tests', () => {
 	});
 
 	test('ROOM_MEMBER_REMOVED: session user is removed from a room with an ongoing meeting', async () => {
-		useStore.getState().addMeeting(meeting);
+		useStore.getState().addMeetings([meeting]);
 		wsEventsHandler({
 			type: WsEventType.ROOM_MEMBER_REMOVED,
 			sentDate: '2023-01-01T00:00:00.000Z',

--- a/src/network/websocket/wsConversationEventsHandler.ts
+++ b/src/network/websocket/wsConversationEventsHandler.ts
@@ -64,7 +64,7 @@ export const wsConversationEventsHandler = (event: WsEvent): void => {
 					state.addRooms([response]);
 					if (response.meetingId) {
 						MeetingsApi.getMeeting(response.id).then((meetingResponse: GetMeetingResponse) =>
-							state.addMeeting(meetingResponse)
+							state.addMeetings([meetingResponse])
 						);
 					}
 				});

--- a/src/network/websocket/wsConversationEventsHandler.ts
+++ b/src/network/websocket/wsConversationEventsHandler.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 import { EventName, sendCustomEvent } from '../../hooks/useEventListener';
+import { getMeetingIdFromRoom } from '../../store/selectors/RoomsSelectors';
 import useStore from '../../store/Store';
 import { GetMeetingResponse } from '../../types/network/responses/meetingsResponses';
 import { GetRoomResponse } from '../../types/network/responses/roomsResponses';
@@ -78,8 +79,9 @@ export const wsConversationEventsHandler = (event: WsEvent): void => {
 		}
 		case WsEventType.ROOM_MEMBER_REMOVED: {
 			if (isMyId(event.userId)) {
-				if (state.meetings[event.roomId]) {
-					state.deleteMeeting(state.meetings[event.roomId].id);
+				const meetingId = getMeetingIdFromRoom(useStore.getState(), event.roomId);
+				if (meetingId) {
+					state.deleteMeeting(meetingId);
 				}
 				state.removeRoom(event.roomId);
 			} else {

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingAudioAnsweredEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingAudioAnsweredEventHandler.test.ts
@@ -26,7 +26,7 @@ beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo('myUserId', 'User');
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 });
 describe('meetingAudioAnsweredEventHandler tests', () => {
 	test('handleRemoteAnswer is been called when the meeting is active', () => {

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingAudioStreamChangedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingAudioStreamChangedEventHandler.test.ts
@@ -38,8 +38,8 @@ beforeEach(() => {
 describe('meetingAudioStreamChangedEventHandler tests', () => {
 	test('New audio participant information are changes into store', () => {
 		meetingAudioStreamChangedEventHandler(event);
-		const meeting = useStore.getState().meetings[room.id];
-		expect(meeting.participants[event.userId].audioStreamOn).toBe(event.active);
+		const meet = useStore.getState().meetings[meeting.id];
+		expect(meet.participants[event.userId].audioStreamOn).toBe(event.active);
 	});
 
 	test('Audio feedback is not sent when event user is not the session user', () => {

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingAudioStreamChangedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingAudioStreamChangedEventHandler.test.ts
@@ -31,7 +31,7 @@ beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo('sessionUserId', 'User');
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 	store.addParticipant(meeting.id, createMockParticipants({ userId: 'sessionUserId' }));
 	store.addParticipant(meeting.id, createMockParticipants({ userId: event.userId }));
 });

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingJoinedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingJoinedEventHandler.test.ts
@@ -30,8 +30,7 @@ beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo('sessionUserId', 'User');
 	store.addRooms([room, groupRoom]);
-	store.addMeeting(meeting);
-	store.addMeeting(groupMeeting);
+	store.addMeetings([meeting, groupMeeting]);
 });
 describe('meetingJoinedEventHandler tests', () => {
 	test('Joined participant information are added into store', () => {

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingJoinedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingJoinedEventHandler.test.ts
@@ -35,8 +35,8 @@ beforeEach(() => {
 describe('meetingJoinedEventHandler tests', () => {
 	test('Joined participant information are added into store', () => {
 		meetingJoinedEventHandler(event);
-		const meeting = useStore.getState().meetings[room.id];
-		expect(meeting.participants[event.userId]).toBeDefined();
+		const meet = useStore.getState().meetings[meeting.id];
+		expect(meet.participants[event.userId]).toBeDefined();
 	});
 
 	test('A custom event is sent if the joined user is the session user and the room is a one-to-one', () => {

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingLeftEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingLeftEventHandler.test.ts
@@ -30,7 +30,7 @@ beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo('myUserId', 'User');
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 	store.meetingConnection(meeting.id, false, undefined, false, undefined);
 	store.addParticipant(meeting.id, createMockParticipants({ userId: event.userId }));
 });

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingLeftEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingLeftEventHandler.test.ts
@@ -37,8 +37,8 @@ beforeEach(() => {
 describe('meetingLeftEventHandler tests', () => {
 	test('Left participant information are removed from store', () => {
 		meetingLeftEventHandler(event);
-		const meeting = useStore.getState().meetings[room.id];
-		expect(meeting.participants[event.userId]).toBeUndefined();
+		const meet = useStore.getState().meetings[meeting.id];
+		expect(meet.participants[event.userId]).toBeUndefined();
 	});
 
 	test('Left participant video subscription is been removed', () => {

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingMediaStreamChangedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingMediaStreamChangedEventHandler.test.ts
@@ -33,7 +33,7 @@ beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo('myUserId', 'User');
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 	store.meetingConnection(meeting.id, false, undefined, false, undefined);
 	store.addParticipant(meeting.id, createMockParticipants({ userId: event.userId }));
 });

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingMediaStreamChangedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingMediaStreamChangedEventHandler.test.ts
@@ -40,8 +40,8 @@ beforeEach(() => {
 describe('meetingMediaStreamChangedEventHandler tests', () => {
 	test('New stream status information are saved into store', () => {
 		meetingMediaStreamChangedEventHandler(event);
-		const meeting = useStore.getState().meetings[room.id];
-		expect(meeting.participants[event.userId].videoStreamOn).toBe(event.active);
+		const meet = useStore.getState().meetings[meeting.id];
+		expect(meet.participants[event.userId].videoStreamOn).toBe(event.active);
 	});
 
 	test('Screen share is pinned when active', () => {

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingParticipantClashedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingParticipantClashedEventHandler.test.ts
@@ -29,7 +29,7 @@ beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo('myUserId', 'User');
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 });
 describe('MeetingParticipantClashedEventHandler tests', () => {
 	test('A custom event is sent if the user is the active meeting', () => {

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingParticipantHandRaisedEventHandler.test.tsx
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingParticipantHandRaisedEventHandler.test.tsx
@@ -31,7 +31,7 @@ beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo('myUserId', 'User');
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 });
 describe('MeetingParticipantClashedEventHandler tests', () => {
 	test('A custom event is sent if the user is the active meeting', () => {

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingParticipantSubscribedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingParticipantSubscribedEventHandler.test.ts
@@ -26,7 +26,7 @@ beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo('myUserId', 'User');
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 });
 describe('meetingParticipantSubscribedEventHandler tests', () => {
 	test('handleParticipantsSubscribed is been called when the meeting is active', () => {

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingParticipantTalkingHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingParticipantTalkingHandler.test.ts
@@ -24,7 +24,7 @@ beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo('myUserId', 'User');
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 });
 describe('meetingParticipantTalkingEventHandler tests', () => {
 	test('Talking user information are saved only the meeting is active', () => {

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingRecordingStartedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingRecordingStartedEventHandler.test.ts
@@ -36,8 +36,8 @@ describe('MeetingRecordingStartedEventHandler tests', () => {
 	test('Meeting starting information are saved into store', () => {
 		meetingRecordingStartedEventHandler(event);
 		const state = useStore.getState();
-		expect(state.meetings[room.id].recStartedAt).toBe(event.sentDate);
-		expect(state.meetings[room.id].recUserId).toBe(event.userId);
+		expect(state.meetings[meeting.id].recStartedAt).toBe(event.sentDate);
+		expect(state.meetings[meeting.id].recUserId).toBe(event.userId);
 	});
 
 	test('A custom event is sent if the user is inside meeting', () => {

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingRecordingStartedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingRecordingStartedEventHandler.test.ts
@@ -30,7 +30,7 @@ beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo('myUserId', 'User');
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 });
 describe('MeetingRecordingStartedEventHandler tests', () => {
 	test('Meeting starting information are saved into store', () => {

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingRecordingStoppedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingRecordingStoppedEventHandler.test.ts
@@ -30,7 +30,7 @@ beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo('myUserId', 'User');
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 });
 describe('MeetingRecordingStoppedEventHandler tests', () => {
 	test('Meeting starting information are reset into store', () => {

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingRecordingStoppedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingRecordingStoppedEventHandler.test.ts
@@ -36,8 +36,8 @@ describe('MeetingRecordingStoppedEventHandler tests', () => {
 	test('Meeting starting information are reset into store', () => {
 		meetingRecordingStoppedEventHandler(event);
 		const state = useStore.getState();
-		expect(state.meetings[room.id].recStartedAt).toBeUndefined();
-		expect(state.meetings[room.id].recUserId).toBeUndefined();
+		expect(state.meetings[meeting.id].recStartedAt).toBeUndefined();
+		expect(state.meetings[meeting.id].recUserId).toBeUndefined();
 	});
 
 	test('A custom event is sent if the session user is inside meeting', () => {

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingSDPAnsweredEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingSDPAnsweredEventHandler.test.ts
@@ -28,7 +28,7 @@ beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo('myUserId', 'User');
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 });
 describe('meetingSDPAnsweredEventHandler tests', () => {
 	test('handleRemoteAnswer is not been called when the meeting is not active', () => {

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingSDPOfferedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingSDPOfferedEventHandler.test.ts
@@ -28,7 +28,7 @@ beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo('myUserId', 'User');
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 });
 describe('meetingSDPOfferedEventHandler tests', () => {
 	test('handleRemoteOffer is been called when the meeting is active', () => {

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingStartedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingStartedEventHandler.test.ts
@@ -30,8 +30,7 @@ beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo('myUserId', 'myusername');
 	store.addRooms([oneToOneRoom, groupRoom]);
-	store.addMeeting(oneToOneMeeting);
-	store.addMeeting(groupMeeting);
+	store.addMeetings([oneToOneMeeting, groupMeeting]);
 });
 describe('MeetingStartedEventHandler tests', () => {
 	test('Meeting starting information are saved into store', () => {

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingStartedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingStartedEventHandler.test.ts
@@ -36,8 +36,8 @@ describe('MeetingStartedEventHandler tests', () => {
 	test('Meeting starting information are saved into store', () => {
 		meetingStartedEventHandler(event);
 		const store = useStore.getState();
-		expect(store.meetings[oneToOneMeeting.roomId].active).toBeTruthy();
-		expect(store.meetings[oneToOneMeeting.roomId].startedAt).toBe(event.startedAt);
+		expect(store.meetings[oneToOneMeeting.id].active).toBeTruthy();
+		expect(store.meetings[oneToOneMeeting.id].startedAt).toBe(event.startedAt);
 	});
 
 	test('Incoming meeting notification is sent if the meeting is from one-to-one room and started by the other user', () => {

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingStoppedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingStoppedEventHandler.test.ts
@@ -27,8 +27,7 @@ beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo('myUserId', 'myusername');
 	store.addRooms([oneToOneRoom, groupRoom]);
-	store.addMeeting(oneToOneMeeting);
-	store.addMeeting(groupMeeting);
+	store.addMeetings([oneToOneMeeting, groupMeeting]);
 });
 describe('MeetingStoppedEventHandler tests', () => {
 	test('Meeting stopped information are saved into store', () => {

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingStoppedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingStoppedEventHandler.test.ts
@@ -33,8 +33,8 @@ describe('MeetingStoppedEventHandler tests', () => {
 	test('Meeting stopped information are saved into store', () => {
 		meetingStoppedEventHandler(event);
 		const store = useStore.getState();
-		expect(store.meetings[oneToOneMeeting.roomId].active).toBeFalsy();
-		expect(store.meetings[oneToOneMeeting.roomId].startedAt).toBeUndefined();
+		expect(store.meetings[oneToOneMeeting.id].active).toBeFalsy();
+		expect(store.meetings[oneToOneMeeting.id].startedAt).toBeUndefined();
 	});
 
 	test('Removed meeting notification is sent if the meeting is from one-to-one room', () => {

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingUserAcceptedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingUserAcceptedEventHandler.test.ts
@@ -28,7 +28,7 @@ beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo('myUserId', 'User');
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 	store.addUserToWaitingList(meeting.id, 'acceptedId');
 });
 describe('MeetingUserAcceptedEventHandler tests', () => {

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingUserAcceptedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingUserAcceptedEventHandler.test.ts
@@ -34,7 +34,7 @@ beforeEach(() => {
 describe('MeetingUserAcceptedEventHandler tests', () => {
 	test('Accepted user is removed from the waiting list', () => {
 		meetingUserAcceptedEventHandler(event);
-		expect(useStore.getState().meetings[room.id].waitingList).not.toContain('acceptedId');
+		expect(useStore.getState().meetings[meeting.id].waitingList).not.toContain('acceptedId');
 	});
 
 	test('Do not send user accepted custom event if another user is accepted', () => {

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingUserRejectedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingUserRejectedEventHandler.test.ts
@@ -41,7 +41,7 @@ beforeEach(() => {
 describe('MeetingUserRejectedEventHandler tests', () => {
 	test('Rejected user is removed from the waiting list', () => {
 		meetingUserRejectedEventHandler(event);
-		expect(useStore.getState().meetings[room.id].waitingList).not.toContain('rejectedId');
+		expect(useStore.getState().meetings[meeting.id].waitingList).not.toContain('rejectedId');
 	});
 
 	test('Do not send user rejected custom event if another user is rejected', () => {

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingUserRejectedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingUserRejectedEventHandler.test.ts
@@ -35,7 +35,7 @@ beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo('myUserId', 'User');
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 	store.addUserToWaitingList(meeting.id, 'rejectedId');
 });
 describe('MeetingUserRejectedEventHandler tests', () => {

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingWaitingParticipantClashedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingWaitingParticipantClashedEventHandler.test.ts
@@ -34,7 +34,7 @@ beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo('myUserId', 'User');
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 	store.addParticipant(meeting.id, createMockParticipants({ userId: 'myUserId' }));
 });
 describe('MeetingWaitingParticipantClashedEventHandler tests', () => {

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingWaitingParticipantJoinedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingWaitingParticipantJoinedEventHandler.test.ts
@@ -43,7 +43,7 @@ describe('MeetingWaitingParticipantJoinedEventHandler tests', () => {
 	test('When a new user joins the waiting room and he is added to waiting list and a custom event is sent', () => {
 		const dispatchEvent = jest.spyOn(window, 'dispatchEvent');
 		meetingWaitingParticipantJoinedEventHandler(event);
-		expect(useStore.getState().meetings[room.id].waitingList).toContain(event.userId);
+		expect(useStore.getState().meetings[meeting.id].waitingList).toContain(event.userId);
 		expect(dispatchEvent).toHaveBeenCalledWith(
 			new CustomEvent(EventName.NEW_WAITING_USER, { detail: event })
 		);

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingWaitingParticipantJoinedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingWaitingParticipantJoinedEventHandler.test.ts
@@ -36,7 +36,7 @@ beforeEach(() => {
 	const store = useStore.getState();
 	store.setLoginInfo('myUserId', 'User');
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 	store.addParticipant(meeting.id, createMockParticipants({ userId: 'myUserId' }));
 });
 describe('MeetingWaitingParticipantJoinedEventHandler tests', () => {

--- a/src/network/websocket/wsMeetingEventHandlers/wsMeetingEventsHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/wsMeetingEventsHandler.test.ts
@@ -41,7 +41,7 @@ describe('wsMeetingEventsHandler', () => {
 			sentDate: '2024-05-30T12:34:56Z'
 		};
 		wsMeetingEventsHandler(event);
-		expect(useStore.getState().meetings[event.roomId]).toBeDefined();
+		expect(useStore.getState().meetings[event.meetingId]).toBeDefined();
 	});
 
 	test('MEETING_STARTED event is handled', () => {

--- a/src/network/websocket/wsMeetingEventHandlers/wsMeetingEventsHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/wsMeetingEventsHandler.test.ts
@@ -75,7 +75,7 @@ describe('wsMeetingEventsHandler', () => {
 	test('MEETING_DELETED event is handled', () => {
 		const store = useStore.getState();
 		store.addRooms([createMockRoom({ id: 'roomId' })]);
-		store.addMeeting(createMockMeeting({ id: 'meetingId', roomId: 'roomId' }));
+		store.addMeetings([createMockMeeting({ id: 'meetingId', roomId: 'roomId' })]);
 		const event: MeetingDeletedEvent = {
 			type: WsEventType.MEETING_DELETED,
 			meetingId: 'meetingId',

--- a/src/network/websocket/wsMeetingEventHandlers/wsMeetingEventsHandler.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/wsMeetingEventsHandler.ts
@@ -32,15 +32,17 @@ export const wsMeetingEventsHandler = (event: WsEvent): void => {
 
 	switch (event.type) {
 		case WsEventType.MEETING_CREATED: {
-			state.addMeeting({
-				id: event.meetingId,
-				name: '',
-				roomId: event.roomId,
-				active: false,
-				participants: [],
-				createdAt: event.sentDate,
-				meetingType: MeetingType.PERMANENT
-			});
+			state.addMeetings([
+				{
+					id: event.meetingId,
+					name: '',
+					roomId: event.roomId,
+					active: false,
+					participants: [],
+					createdAt: event.sentDate,
+					meetingType: MeetingType.PERMANENT
+				}
+			]);
 			break;
 		}
 		case WsEventType.MEETING_STARTED: {

--- a/src/settings/components/WaitingListSnackbar.test.tsx
+++ b/src/settings/components/WaitingListSnackbar.test.tsx
@@ -30,7 +30,7 @@ beforeEach(() => {
 	const store = useStore.getState();
 	store.setUserInfo([user, user0]);
 	store.addRooms([room]);
-	store.addMeeting(meeting);
+	store.addMeetings([meeting]);
 });
 
 describe('WaitingListSnackbar', () => {

--- a/src/settings/components/WaitingListSnackbar.tsx
+++ b/src/settings/components/WaitingListSnackbar.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next';
 
 import useEventListener, { EventName, NewWaitingUserEvent } from '../../hooks/useEventListener';
 import {
-	getMeetingByMeetingId,
+	getMeeting,
 	getWaitingListSizeForMyVirtualMeeting
 } from '../../store/selectors/MeetingSelectors';
 import useStore from '../../store/Store';
@@ -33,7 +33,7 @@ const WaitingListSnackbar = (): ReactElement | null => {
 	const [showWaitingUserSnackbar, setShowWaitingUserSnackbar] = useState(false);
 	const [meetingId, setMeetingId] = useState<string>('');
 
-	const meeting = useStore((store) => getMeetingByMeetingId(store, meetingId));
+	const meeting = useStore((store) => getMeeting(store, meetingId));
 
 	const snackbarLabel = t(
 		'meeting.snackbar.waitingInfo',

--- a/src/store/selectors/MeetingSelectors.ts
+++ b/src/store/selectors/MeetingSelectors.ts
@@ -11,23 +11,20 @@ import { STREAM_TYPE, TileData } from '../../types/store/ActiveMeetingTypes';
 import { Meeting, MeetingParticipantMap } from '../../types/store/MeetingTypes';
 import { RootStore } from '../../types/store/StoreTypes';
 
-export const getMeeting = (store: RootStore, roomId: string): Meeting | undefined =>
-	store.meetings[roomId];
+export const getMeeting = (store: RootStore, meetingId: string): Meeting | undefined =>
+	store.meetings[meetingId];
 
-export const getMeetingByMeetingId = (store: RootStore, meetingId: string): Meeting | undefined =>
-	find(store.meetings, (meeting) => meeting.id === meetingId);
+export const getMeetingByRoomId = (store: RootStore, roomId: string): Meeting | undefined =>
+	find(store.meetings, (meeting) => meeting.roomId === roomId);
 
 export const getRoomIdByMeetingId = (store: RootStore, meetingId: string): string | undefined =>
-	find(store.meetings, (meeting) => meeting.id === meetingId)?.roomId;
-
-export const getRoomIdFromMeeting = (store: RootStore, meetingId: string): string | undefined =>
-	find(store.meetings, (meeting) => meeting.id === meetingId)?.roomId;
+	store.meetings[meetingId]?.roomId;
 
 export const getMeetingActive = (store: RootStore, roomId: string): boolean =>
-	store.meetings[roomId] && store.meetings[roomId].active;
+	!!find(store.meetings, (meeting) => meeting.roomId === roomId)?.active;
 
 export const getMeetingActiveByMeetingId = (store: RootStore, meetingId: string): boolean =>
-	!!find(store.meetings, (meeting) => meeting.id === meetingId)?.active;
+	!!store.meetings[meetingId]?.active;
 
 export const getIfThereAreActiveVirtualRooms = (store: RootStore): boolean =>
 	some(
@@ -35,38 +32,35 @@ export const getIfThereAreActiveVirtualRooms = (store: RootStore): boolean =>
 		(meeting) => meeting.meetingType === MeetingType.SCHEDULED && meeting.active
 	);
 
-const FALLBACK_EMPTY_PARTICIPANTS = {};
-
-export const getMeetingParticipants = (store: RootStore, roomId: string): MeetingParticipantMap =>
-	store.meetings[roomId] ? store.meetings[roomId].participants : FALLBACK_EMPTY_PARTICIPANTS;
-
-export const getMeetingParticipantsByMeetingId = (
+export const getMeetingParticipants = (
 	store: RootStore,
 	meetingId: string
-): MeetingParticipantMap | undefined =>
-	find(store.meetings, (meeting) => meeting.id === meetingId)?.participants;
+): MeetingParticipantMap | undefined => store.meetings[meetingId]?.participants;
+
+export const getMeetingParticipantsByRoomId = (
+	store: RootStore,
+	roomId: string
+): MeetingParticipantMap | undefined => {
+	const meeting = find(store.meetings, (meeting) => meeting.roomId === roomId);
+	return meeting?.participants;
+};
 
 export const getMyMeetingParticipation = (store: RootStore, roomId: string): boolean => {
-	if (store.meetings[roomId]?.participants && store.session.id != null) {
-		const sessionMember = find(
-			store.meetings[roomId].participants,
-			(member) => member.userId === store.session.id
-		);
+	const participants = getMeetingParticipantsByRoomId(store, roomId);
+	if (participants && store.session.id != null) {
+		const sessionMember = find(participants, (member) => member.userId === store.session.id);
 		return sessionMember != null;
 	}
 	return false;
 };
 
-export const getNumberOfMeetingParticipants = (
-	store: RootStore,
-	roomId: string
-): number | undefined => size(store.meetings[roomId]?.participants);
+export const getNumberOfMeetingParticipants = (store: RootStore, roomId: string): number =>
+	size(getMeetingParticipantsByRoomId(store, roomId));
 
 export const getNumberOfMeetingParticipantsByMeetingId = (
 	store: RootStore,
 	meetingId: string
-): number | undefined =>
-	size(find(store.meetings, (meeting) => meeting.id === meetingId)?.participants);
+): number => size(store.meetings[meetingId]?.participants);
 
 export const getParticipantAudioStatus = (
 	store: RootStore,
@@ -74,7 +68,7 @@ export const getParticipantAudioStatus = (
 	userId: string | undefined
 ): boolean => {
 	if (!meetingId || !userId) return false;
-	const meeting = find(store.meetings, (meeting) => meeting.id === meetingId);
+	const meeting = store.meetings[meetingId];
 	const participant = find(meeting?.participants, (participant) => participant.userId === userId);
 	return participant?.audioStreamOn ?? false;
 };
@@ -84,7 +78,8 @@ export const getParticipantVideoStatus = (
 	meetingId: string | undefined,
 	userId: string | undefined
 ): boolean => {
-	const meeting = find(store.meetings, (meeting) => meeting.id === meetingId);
+	if (!meetingId || !userId) return false;
+	const meeting = store.meetings[meetingId];
 	const participant = find(meeting?.participants, (participant) => participant.userId === userId);
 	return participant?.videoStreamOn ?? false;
 };
@@ -94,7 +89,8 @@ export const getParticipantScreenStatus = (
 	meetingId: string | undefined,
 	userId: string | undefined
 ): boolean => {
-	const meeting = find(store.meetings, (meeting) => meeting.id === meetingId);
+	if (!meetingId || !userId) return false;
+	const meeting = store.meetings[meetingId];
 	const participant = find(meeting?.participants, (participant) => participant.userId === userId);
 	return participant?.screenStreamOn ?? false;
 };
@@ -103,7 +99,7 @@ const centralTileData: TileData = <TileData>{};
 
 export const getCentralTileData = (store: RootStore, meetingId: string): TileData | undefined => {
 	Object.assign(centralTileData, {});
-	const meeting = find(store.meetings, (meeting) => meeting.id === meetingId);
+	const meeting = store.meetings[meetingId];
 	const participant = find(
 		meeting?.participants,
 		(participant) => participant.userId !== store.session.id
@@ -130,7 +126,7 @@ export const getCentralTileData = (store: RootStore, meetingId: string): TileDat
 };
 
 export const getNumberOfTiles = (store: RootStore, meetingId: string): number => {
-	const meeting = find(store.meetings, (meeting) => meeting.id === meetingId);
+	const meeting = store.meetings[meetingId];
 	if (meeting) {
 		const participantWithScreen = filter(
 			meeting.participants,
@@ -144,7 +140,7 @@ export const getNumberOfTiles = (store: RootStore, meetingId: string): number =>
 const emptyList: string[] = [];
 
 export const getWaitingList = (store: RootStore, meetingId: string): string[] => {
-	const meeting = find(store.meetings, (meeting) => meeting.id === meetingId);
+	const meeting = store.meetings[meetingId];
 	if (meeting) {
 		return meeting.waitingList || emptyList;
 	}
@@ -170,27 +166,17 @@ export const getMeetingStartedAt = (
 	store: RootStore,
 	meetingId: string | undefined
 ): string | undefined => {
-	const meeting = find(store.meetings, (meeting) => meeting.id === meetingId);
-	return meeting?.startedAt;
+	if (!meetingId) return undefined;
+	return store.meetings[meetingId]?.startedAt;
 };
 
 export const getMeetingRecordingTimestamp = (
 	store: RootStore,
 	meetingId: string
-): string | undefined => {
-	const meeting = find(store.meetings, (meeting) => meeting.id === meetingId);
-	return meeting?.recStartedAt;
-};
+): string | undefined => store.meetings[meetingId]?.recStartedAt;
 
-export const getIsMeetingRecording = (store: RootStore, meetingId: string): boolean => {
-	const meeting = find(store.meetings, (meeting) => meeting.id === meetingId);
-	return !!meeting?.recStartedAt;
-};
+export const getIsMeetingRecording = (store: RootStore, meetingId: string): boolean =>
+	!!store.meetings[meetingId]?.recStartedAt;
 
-export const getStartRecordingUserId = (
-	store: RootStore,
-	meetingId: string
-): string | undefined => {
-	const meeting = find(store.meetings, (meeting) => meeting.id === meetingId);
-	return meeting?.recUserId;
-};
+export const getStartRecordingUserId = (store: RootStore, meetingId: string): string | undefined =>
+	store.meetings[meetingId]?.recUserId;

--- a/src/store/slices/MeetingsStoreSlice.test.ts
+++ b/src/store/slices/MeetingsStoreSlice.test.ts
@@ -55,7 +55,7 @@ beforeEach(() => {
 describe('Test components slice', () => {
 	test('setMeetings setter', () => {
 		const { result } = renderHook(() => useStore());
-		act(() => result.current.setMeetings([mockMeeting0, mockMeeting1, mockMeeting2]));
+		act(() => result.current.addMeetings([mockMeeting0, mockMeeting1, mockMeeting2]));
 
 		// Check store data
 		expect(size(result.current.meetings)).toBe(3);
@@ -75,7 +75,7 @@ describe('Test components slice', () => {
 
 	test('addMeeting setter', () => {
 		const { result } = renderHook(() => useStore());
-		act(() => result.current.addMeeting(mockMeeting0));
+		act(() => result.current.addMeetings([mockMeeting0]));
 
 		// Check store data
 		const meeting0 = result.current.meetings[mockMeeting0.roomId];
@@ -91,10 +91,10 @@ describe('Test components slice', () => {
 	test('Combination of set components, add components, and remove components setters', () => {
 		const { result } = renderHook(() => useStore());
 
-		act(() => result.current.setMeetings([mockMeeting0, mockMeeting1]));
+		act(() => result.current.addMeetings([mockMeeting0, mockMeeting1]));
 		expect(size(result.current.meetings)).toBe(2);
 
-		act(() => result.current.addMeeting(mockMeeting2));
+		act(() => result.current.addMeetings([mockMeeting2]));
 		expect(size(result.current.meetings)).toBe(3);
 
 		act(() => result.current.deleteMeeting(mockMeeting1.id));
@@ -104,7 +104,7 @@ describe('Test components slice', () => {
 	test('Start a meeting', () => {
 		const { result } = renderHook(() => useStore());
 		act(() => {
-			result.current.addMeeting(mockMeeting1);
+			result.current.addMeetings([mockMeeting1]);
 			result.current.startMeeting(mockMeeting1.id, '2022-08-25T18:25:29.961+02:00');
 		});
 
@@ -117,7 +117,7 @@ describe('Test components slice', () => {
 	test('Stop a meeting', () => {
 		const { result } = renderHook(() => useStore());
 		act(() => {
-			result.current.addMeeting(mockMeeting0);
+			result.current.addMeetings([mockMeeting0]);
 			result.current.stopMeeting(mockMeeting0.id);
 		});
 
@@ -131,7 +131,7 @@ describe('Test components slice', () => {
 		test('Set a waiting list from scratch', () => {
 			const { result } = renderHook(() => useStore());
 			act(() => {
-				result.current.addMeeting(scheduleMeeting);
+				result.current.addMeetings([scheduleMeeting]);
 				result.current.setWaitingList(scheduleMeeting.id, ['userId0', 'userId1']);
 			});
 
@@ -146,7 +146,7 @@ describe('Test components slice', () => {
 		test('Replace existing waiting list', () => {
 			const { result } = renderHook(() => useStore());
 			act(() => {
-				result.current.addMeeting(scheduleMeeting);
+				result.current.addMeetings([scheduleMeeting]);
 				result.current.setWaitingList(scheduleMeeting.id, ['userId0', 'userId1']);
 				result.current.setWaitingList(scheduleMeeting.id, ['userId2', 'userId3']);
 			});
@@ -164,7 +164,7 @@ describe('Test components slice', () => {
 		test('Add a user to an empty waiting list in which the user is not present', () => {
 			const { result } = renderHook(() => useStore());
 			act(() => {
-				result.current.addMeeting(scheduleMeeting);
+				result.current.addMeetings([scheduleMeeting]);
 				result.current.addUserToWaitingList(scheduleMeeting.id, 'userId0');
 			});
 
@@ -178,7 +178,7 @@ describe('Test components slice', () => {
 		test('Add a user to a waiting list in which the user is already present', () => {
 			const { result } = renderHook(() => useStore());
 			act(() => {
-				result.current.addMeeting(scheduleMeeting);
+				result.current.addMeetings([scheduleMeeting]);
 				result.current.setWaitingList(scheduleMeeting.id, ['userId0', 'userId1']);
 				result.current.addUserToWaitingList(scheduleMeeting.id, 'userId0');
 			});
@@ -193,7 +193,7 @@ describe('Test components slice', () => {
 		test('Remove a user from a waiting list in which the user is present', () => {
 			const { result } = renderHook(() => useStore());
 			act(() => {
-				result.current.addMeeting(scheduleMeeting);
+				result.current.addMeetings([scheduleMeeting]);
 				result.current.setWaitingList(scheduleMeeting.id, ['userId0', 'userId1']);
 				result.current.removeUserFromWaitingList(scheduleMeeting.id, 'userId0');
 			});
@@ -208,7 +208,7 @@ describe('Test components slice', () => {
 		test('Remove a user from a waiting list in which the user is not present', () => {
 			const { result } = renderHook(() => useStore());
 			act(() => {
-				result.current.addMeeting(scheduleMeeting);
+				result.current.addMeetings([scheduleMeeting]);
 				result.current.setWaitingList(scheduleMeeting.id, ['userId0', 'userId1']);
 				result.current.removeUserFromWaitingList(scheduleMeeting.id, 'userId2');
 			});
@@ -226,7 +226,7 @@ describe('Test components slice', () => {
 		test('Start a new recording', () => {
 			const { result } = renderHook(() => useStore());
 			act(() => {
-				result.current.addMeeting(scheduleMeeting);
+				result.current.addMeetings([scheduleMeeting]);
 				result.current.startRecording(
 					scheduleMeeting.id,
 					'2022-08-25T18:24:28.961+02:00',
@@ -242,7 +242,7 @@ describe('Test components slice', () => {
 		test('Stop an ongoing recording', () => {
 			const { result } = renderHook(() => useStore());
 			act(() => {
-				result.current.addMeeting(scheduleMeeting);
+				result.current.addMeetings([scheduleMeeting]);
 				result.current.stopRecording(scheduleMeeting.id);
 			});
 

--- a/src/store/slices/MeetingsStoreSlice.test.ts
+++ b/src/store/slices/MeetingsStoreSlice.test.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { act, renderHook } from '@testing-library/react';
 import { size } from 'lodash';
 
 import { createMockMeeting, createMockParticipants, createMockRoom } from '../../tests/createMock';
+import { STREAM_TYPE } from '../../types/store/ActiveMeetingTypes';
 import useStore from '../Store';
 
 const mockParticipant0 = createMockParticipants({
@@ -22,9 +22,12 @@ const mockParticipant1 = createMockParticipants({
 	videoStreamEnabled: true
 });
 
+const room1 = createMockRoom({ id: 'roomId1' });
+const temporaryRoom = createMockRoom({ id: 'temporaryRoomId' });
+
 const mockMeeting0 = createMockMeeting({
 	id: 'meetingId0',
-	roomId: 'roomId0',
+	roomId: room1.id,
 	participants: [mockParticipant0, mockParticipant1],
 	createdAt: '2022-08-25T17:24:28.961+02:00',
 	active: true,
@@ -43,100 +46,131 @@ const mockMeeting2 = createMockMeeting({
 	participants: [mockParticipant1],
 	createdAt: '2022-08-27T19:34:28.961+02:00'
 });
-
-const temporaryRoom = createMockRoom();
-const scheduleMeeting = createMockMeeting({ roomId: temporaryRoom.id });
+const scheduleMeeting = createMockMeeting({ id: 'scheduledMeetingId', roomId: temporaryRoom.id });
 
 beforeEach(() => {
 	const store = useStore.getState();
 	store.addRooms([temporaryRoom]);
 });
 
-describe('Test components slice', () => {
-	test('setMeetings setter', () => {
-		const { result } = renderHook(() => useStore());
-		act(() => result.current.addMeetings([mockMeeting0, mockMeeting1, mockMeeting2]));
+describe('MeetingStoreSlice tests', () => {
+	describe('Meeting lifecycle', () => {
+		test('Add a meeting', () => {
+			useStore.getState().addRooms([]);
+			useStore.getState().addMeetings([mockMeeting0]);
 
-		// Check store data
-		expect(size(result.current.meetings)).toBe(3);
-		const meeting0 = result.current.meetings[mockMeeting0.id];
-		expect(meeting0).not.toBeNull();
-		expect(meeting0.id).toBe(mockMeeting0.id);
-		expect(meeting0.roomId).toBe(mockMeeting0.roomId);
-		expect(size(meeting0.participants)).toBe(size(mockMeeting0.participants));
-		expect(meeting0.createdAt).toBe(mockMeeting0.createdAt);
-		expect(meeting0.active).toBeTruthy();
-		expect(meeting0.startedAt).toBe(mockMeeting0.startedAt);
+			// Check store data
+			const store = useStore.getState();
+			const meeting0 = store.meetings[mockMeeting0.id];
+			expect(meeting0).not.toBeNull();
+			expect(meeting0.id).toBe(mockMeeting0.id);
+			expect(meeting0.roomId).toBe(mockMeeting0.roomId);
+			expect(size(meeting0.participants)).toBe(size(mockMeeting0.participants));
+			expect(meeting0.createdAt).toBe(mockMeeting0.createdAt);
+			expect(meeting0.active).toBeTruthy();
+			expect(meeting0.startedAt).toBe(mockMeeting0.startedAt);
 
-		const meeting1 = result.current.meetings[mockMeeting1.id];
-		expect(meeting1.active).toBeFalsy();
-		expect(meeting1.startedAt).toBeUndefined();
-	});
-
-	test('addMeeting setter', () => {
-		const { result } = renderHook(() => useStore());
-		act(() => result.current.addMeetings([mockMeeting0]));
-
-		// Check store data
-		const meeting0 = result.current.meetings[mockMeeting0.id];
-		expect(meeting0).not.toBeNull();
-		expect(meeting0.id).toBe(mockMeeting0.id);
-		expect(meeting0.roomId).toBe(mockMeeting0.roomId);
-		expect(size(meeting0.participants)).toBe(size(mockMeeting0.participants));
-		expect(meeting0.createdAt).toBe(mockMeeting0.createdAt);
-		expect(meeting0.active).toBeTruthy();
-		expect(meeting0.startedAt).toBe(mockMeeting0.startedAt);
-	});
-
-	test('Combination of set components, add components, and remove components setters', () => {
-		const { result } = renderHook(() => useStore());
-
-		act(() => result.current.addMeetings([mockMeeting0, mockMeeting1]));
-		expect(size(result.current.meetings)).toBe(2);
-
-		act(() => result.current.addMeetings([mockMeeting2]));
-		expect(size(result.current.meetings)).toBe(3);
-
-		act(() => result.current.deleteMeeting(mockMeeting1.id));
-		expect(size(result.current.meetings)).toBe(2);
-	});
-
-	test('Start a meeting', () => {
-		const { result } = renderHook(() => useStore());
-		act(() => {
-			result.current.addMeetings([mockMeeting1]);
-			result.current.startMeeting(mockMeeting1.id, '2022-08-25T18:25:29.961+02:00');
+			// Check room data
+			expect(store.rooms[mockMeeting0.roomId].meetingId).toBe(mockMeeting0.id);
 		});
 
-		// Check store data
-		const meeting1 = result.current.meetings[mockMeeting1.id];
-		expect(meeting1.active).toBeTruthy();
-		expect(meeting1.startedAt).toBe('2022-08-25T18:25:29.961+02:00');
-	});
+		test('Add multiple meetings', () => {
+			useStore.getState().addMeetings([mockMeeting0, mockMeeting1, mockMeeting2]);
 
-	test('Stop a meeting', () => {
-		const { result } = renderHook(() => useStore());
-		act(() => {
-			result.current.addMeetings([mockMeeting0]);
-			result.current.stopMeeting(mockMeeting0.id);
+			// Check store data
+			const store = useStore.getState();
+			expect(size(store.meetings)).toBe(3);
+			const meeting0 = store.meetings[mockMeeting0.id];
+			expect(meeting0).not.toBeNull();
+			expect(meeting0.id).toBe(mockMeeting0.id);
+			expect(meeting0.roomId).toBe(mockMeeting0.roomId);
+			const meeting1 = store.meetings[mockMeeting1.id];
+			expect(meeting1.active).toBeFalsy();
+			expect(meeting1.startedAt).toBeUndefined();
 		});
 
-		// Check store data
-		const meeting0 = result.current.meetings[mockMeeting0.id];
-		expect(meeting0.active).toBeFalsy();
-		expect(meeting0.startedAt).toBeUndefined();
+		test('Remove meeting', () => {
+			useStore.getState().addMeetings([mockMeeting0, mockMeeting1]);
+			useStore.getState().deleteMeeting(mockMeeting0.id);
+
+			// Check store data
+			const store = useStore.getState();
+			expect(size(store.meetings)).toBe(1);
+			expect(store.meetings[mockMeeting0.id]).toBeFalsy();
+		});
+	});
+
+	describe('Meeting active status', () => {
+		test('Set a meeting as active', () => {
+			useStore.getState().addMeetings([mockMeeting0]);
+			useStore.getState().startMeeting(mockMeeting0.id, '2023-08-25T18:25:29.961+02:00');
+
+			// Check store data
+			const meeting0 = useStore.getState().meetings[mockMeeting0.id];
+			expect(meeting0.active).toBeTruthy();
+			expect(meeting0.startedAt).toBe('2023-08-25T18:25:29.961+02:00');
+		});
+
+		test('Set a meeting as disactive', () => {
+			useStore.getState().addMeetings([mockMeeting0]);
+			useStore.getState().startMeeting(mockMeeting0.id, '2022-08-25T18:25:29.961+02:00');
+			useStore.getState().stopMeeting(mockMeeting0.id);
+
+			// Check store data
+			const meeting0 = useStore.getState().meetings[mockMeeting0.id];
+			expect(meeting0.active).toBeFalsy();
+			expect(meeting0.startedAt).toBeUndefined();
+		});
+	});
+
+	describe('Meeting participants', () => {
+		test('Add a participant', () => {
+			useStore.getState().addMeetings([mockMeeting1]);
+			useStore.getState().addParticipant(mockMeeting1.id, mockParticipant1);
+
+			// Check store data
+			const { participants } = useStore.getState().meetings[mockMeeting1.id];
+			expect(size(participants)).toBe(2);
+			expect(participants[mockParticipant1.userId]).toBeDefined();
+		});
+
+		test('Remove a participant', () => {
+			useStore.getState().addMeetings([mockMeeting0]);
+			useStore.getState().removeParticipant(mockMeeting0.id, mockParticipant1.userId);
+
+			// Check store data
+			const { participants } = useStore.getState().meetings[mockMeeting0.id];
+			expect(size(participants)).toBe(1);
+			expect(participants[mockParticipant1.userId]).toBeUndefined();
+		});
+
+		test('Update participant stream status', () => {
+			useStore.getState().addMeetings([mockMeeting0]);
+			useStore
+				.getState()
+				.changeStreamStatus(mockMeeting0.id, mockParticipant1.userId, STREAM_TYPE.AUDIO, true);
+			useStore
+				.getState()
+				.changeStreamStatus(mockMeeting0.id, mockParticipant1.userId, STREAM_TYPE.VIDEO, false);
+			useStore
+				.getState()
+				.changeStreamStatus(mockMeeting0.id, mockParticipant1.userId, STREAM_TYPE.SCREEN, true);
+
+			// Check store data
+			const { participants } = useStore.getState().meetings[mockMeeting0.id];
+			expect(participants[mockParticipant1.userId].audioStreamOn).toBeTruthy();
+			expect(participants[mockParticipant1.userId].videoStreamOn).toBeFalsy();
+			expect(participants[mockParticipant1.userId].screenStreamOn).toBeTruthy();
+		});
 	});
 
 	describe('Waiting List', () => {
 		test('Set a waiting list from scratch', () => {
-			const { result } = renderHook(() => useStore());
-			act(() => {
-				result.current.addMeetings([scheduleMeeting]);
-				result.current.setWaitingList(scheduleMeeting.id, ['userId0', 'userId1']);
-			});
+			useStore.getState().addMeetings([scheduleMeeting]);
+			useStore.getState().setWaitingList(scheduleMeeting.id, ['userId0', 'userId1']);
 
 			// Check store data
-			const { waitingList } = result.current.meetings[scheduleMeeting.id];
+			const { waitingList } = useStore.getState().meetings[scheduleMeeting.id];
 			expect(waitingList).not.toBeNull();
 			expect(size(waitingList)).toBe(2);
 			expect(waitingList).toContain('userId0');
@@ -144,15 +178,12 @@ describe('Test components slice', () => {
 		});
 
 		test('Replace existing waiting list', () => {
-			const { result } = renderHook(() => useStore());
-			act(() => {
-				result.current.addMeetings([scheduleMeeting]);
-				result.current.setWaitingList(scheduleMeeting.id, ['userId0', 'userId1']);
-				result.current.setWaitingList(scheduleMeeting.id, ['userId2', 'userId3']);
-			});
+			useStore.getState().addMeetings([scheduleMeeting]);
+			useStore.getState().setWaitingList(scheduleMeeting.id, ['userId0', 'userId1']);
+			useStore.getState().setWaitingList(scheduleMeeting.id, ['userId2', 'userId3']);
 
 			// Check store data
-			const { waitingList } = result.current.meetings[scheduleMeeting.id];
+			const { waitingList } = useStore.getState().meetings[scheduleMeeting.id];
 			expect(waitingList).not.toBeNull();
 			expect(size(waitingList)).toBe(2);
 			expect(waitingList).not.toContain('userId0');
@@ -162,28 +193,22 @@ describe('Test components slice', () => {
 		});
 
 		test('Add a user to an empty waiting list in which the user is not present', () => {
-			const { result } = renderHook(() => useStore());
-			act(() => {
-				result.current.addMeetings([scheduleMeeting]);
-				result.current.addUserToWaitingList(scheduleMeeting.id, 'userId0');
-			});
+			useStore.getState().addMeetings([scheduleMeeting]);
+			useStore.getState().addUserToWaitingList(scheduleMeeting.id, 'userId0');
 
 			// Check store data
-			const { waitingList } = result.current.meetings[scheduleMeeting.id];
+			const { waitingList } = useStore.getState().meetings[scheduleMeeting.id];
 			expect(waitingList).not.toBeNull();
 			expect(size(waitingList)).toBe(1);
 			expect(waitingList).toContain('userId0');
 		});
 
 		test('Add a user to a waiting list in which the user is already present', () => {
-			const { result } = renderHook(() => useStore());
-			act(() => {
-				result.current.addMeetings([scheduleMeeting]);
-				result.current.setWaitingList(scheduleMeeting.id, ['userId0', 'userId1']);
-				result.current.addUserToWaitingList(scheduleMeeting.id, 'userId0');
-			});
+			useStore.getState().addMeetings([scheduleMeeting]);
+			useStore.getState().setWaitingList(scheduleMeeting.id, ['userId0', 'userId1']);
+			useStore.getState().addUserToWaitingList(scheduleMeeting.id, 'userId0');
 
-			const { waitingList } = result.current.meetings[scheduleMeeting.id];
+			const { waitingList } = useStore.getState().meetings[scheduleMeeting.id];
 			expect(waitingList).not.toBeNull();
 			expect(size(waitingList)).toBe(2);
 			expect(waitingList).toContain('userId0');
@@ -191,14 +216,11 @@ describe('Test components slice', () => {
 		});
 
 		test('Remove a user from a waiting list in which the user is present', () => {
-			const { result } = renderHook(() => useStore());
-			act(() => {
-				result.current.addMeetings([scheduleMeeting]);
-				result.current.setWaitingList(scheduleMeeting.id, ['userId0', 'userId1']);
-				result.current.removeUserFromWaitingList(scheduleMeeting.id, 'userId0');
-			});
+			useStore.getState().addMeetings([scheduleMeeting]);
+			useStore.getState().setWaitingList(scheduleMeeting.id, ['userId0', 'userId1']);
+			useStore.getState().removeUserFromWaitingList(scheduleMeeting.id, 'userId0');
 
-			const { waitingList } = result.current.meetings[scheduleMeeting.id];
+			const { waitingList } = useStore.getState().meetings[scheduleMeeting.id];
 			expect(waitingList).not.toBeNull();
 			expect(size(waitingList)).toBe(1);
 			expect(waitingList).toContain('userId1');
@@ -206,14 +228,11 @@ describe('Test components slice', () => {
 		});
 
 		test('Remove a user from a waiting list in which the user is not present', () => {
-			const { result } = renderHook(() => useStore());
-			act(() => {
-				result.current.addMeetings([scheduleMeeting]);
-				result.current.setWaitingList(scheduleMeeting.id, ['userId0', 'userId1']);
-				result.current.removeUserFromWaitingList(scheduleMeeting.id, 'userId2');
-			});
+			useStore.getState().addMeetings([scheduleMeeting]);
+			useStore.getState().setWaitingList(scheduleMeeting.id, ['userId0', 'userId1']);
+			useStore.getState().removeUserFromWaitingList(scheduleMeeting.id, 'userId2');
 
-			const { waitingList } = result.current.meetings[scheduleMeeting.id];
+			const { waitingList } = useStore.getState().meetings[scheduleMeeting.id];
 			expect(waitingList).not.toBeNull();
 			expect(size(waitingList)).toBe(2);
 			expect(waitingList).toContain('userId0');
@@ -224,29 +243,21 @@ describe('Test components slice', () => {
 
 	describe('Recording', () => {
 		test('Start a new recording', () => {
-			const { result } = renderHook(() => useStore());
-			act(() => {
-				result.current.addMeetings([scheduleMeeting]);
-				result.current.startRecording(
-					scheduleMeeting.id,
-					'2022-08-25T18:24:28.961+02:00',
-					'userId0'
-				);
-			});
+			useStore.getState().addMeetings([scheduleMeeting]);
+			useStore
+				.getState()
+				.startRecording(scheduleMeeting.id, '2022-08-25T18:24:28.961+02:00', 'userId0');
 
-			const { recStartedAt, recUserId } = result.current.meetings[scheduleMeeting.id];
+			const { recStartedAt, recUserId } = useStore.getState().meetings[scheduleMeeting.id];
 			expect(recStartedAt).toBe('2022-08-25T18:24:28.961+02:00');
 			expect(recUserId).toBe('userId0');
 		});
 
 		test('Stop an ongoing recording', () => {
-			const { result } = renderHook(() => useStore());
-			act(() => {
-				result.current.addMeetings([scheduleMeeting]);
-				result.current.stopRecording(scheduleMeeting.id);
-			});
+			useStore.getState().addMeetings([scheduleMeeting]);
+			useStore.getState().stopRecording(scheduleMeeting.id);
 
-			const { recStartedAt, recUserId } = result.current.meetings[scheduleMeeting.id];
+			const { recStartedAt, recUserId } = useStore.getState().meetings[scheduleMeeting.id];
 			expect(recStartedAt).toBeUndefined();
 			expect(recUserId).toBeUndefined();
 		});

--- a/src/store/slices/MeetingsStoreSlice.test.ts
+++ b/src/store/slices/MeetingsStoreSlice.test.ts
@@ -59,7 +59,7 @@ describe('Test components slice', () => {
 
 		// Check store data
 		expect(size(result.current.meetings)).toBe(3);
-		const meeting0 = result.current.meetings[mockMeeting0.roomId];
+		const meeting0 = result.current.meetings[mockMeeting0.id];
 		expect(meeting0).not.toBeNull();
 		expect(meeting0.id).toBe(mockMeeting0.id);
 		expect(meeting0.roomId).toBe(mockMeeting0.roomId);
@@ -68,7 +68,7 @@ describe('Test components slice', () => {
 		expect(meeting0.active).toBeTruthy();
 		expect(meeting0.startedAt).toBe(mockMeeting0.startedAt);
 
-		const meeting1 = result.current.meetings[mockMeeting1.roomId];
+		const meeting1 = result.current.meetings[mockMeeting1.id];
 		expect(meeting1.active).toBeFalsy();
 		expect(meeting1.startedAt).toBeUndefined();
 	});
@@ -78,7 +78,7 @@ describe('Test components slice', () => {
 		act(() => result.current.addMeetings([mockMeeting0]));
 
 		// Check store data
-		const meeting0 = result.current.meetings[mockMeeting0.roomId];
+		const meeting0 = result.current.meetings[mockMeeting0.id];
 		expect(meeting0).not.toBeNull();
 		expect(meeting0.id).toBe(mockMeeting0.id);
 		expect(meeting0.roomId).toBe(mockMeeting0.roomId);
@@ -109,7 +109,7 @@ describe('Test components slice', () => {
 		});
 
 		// Check store data
-		const meeting1 = result.current.meetings[mockMeeting1.roomId];
+		const meeting1 = result.current.meetings[mockMeeting1.id];
 		expect(meeting1.active).toBeTruthy();
 		expect(meeting1.startedAt).toBe('2022-08-25T18:25:29.961+02:00');
 	});
@@ -122,7 +122,7 @@ describe('Test components slice', () => {
 		});
 
 		// Check store data
-		const meeting0 = result.current.meetings[mockMeeting0.roomId];
+		const meeting0 = result.current.meetings[mockMeeting0.id];
 		expect(meeting0.active).toBeFalsy();
 		expect(meeting0.startedAt).toBeUndefined();
 	});
@@ -136,7 +136,7 @@ describe('Test components slice', () => {
 			});
 
 			// Check store data
-			const { waitingList } = result.current.meetings[temporaryRoom.id];
+			const { waitingList } = result.current.meetings[scheduleMeeting.id];
 			expect(waitingList).not.toBeNull();
 			expect(size(waitingList)).toBe(2);
 			expect(waitingList).toContain('userId0');
@@ -152,7 +152,7 @@ describe('Test components slice', () => {
 			});
 
 			// Check store data
-			const { waitingList } = result.current.meetings[temporaryRoom.id];
+			const { waitingList } = result.current.meetings[scheduleMeeting.id];
 			expect(waitingList).not.toBeNull();
 			expect(size(waitingList)).toBe(2);
 			expect(waitingList).not.toContain('userId0');
@@ -169,7 +169,7 @@ describe('Test components slice', () => {
 			});
 
 			// Check store data
-			const { waitingList } = result.current.meetings[temporaryRoom.id];
+			const { waitingList } = result.current.meetings[scheduleMeeting.id];
 			expect(waitingList).not.toBeNull();
 			expect(size(waitingList)).toBe(1);
 			expect(waitingList).toContain('userId0');
@@ -183,7 +183,7 @@ describe('Test components slice', () => {
 				result.current.addUserToWaitingList(scheduleMeeting.id, 'userId0');
 			});
 
-			const { waitingList } = result.current.meetings[temporaryRoom.id];
+			const { waitingList } = result.current.meetings[scheduleMeeting.id];
 			expect(waitingList).not.toBeNull();
 			expect(size(waitingList)).toBe(2);
 			expect(waitingList).toContain('userId0');
@@ -198,7 +198,7 @@ describe('Test components slice', () => {
 				result.current.removeUserFromWaitingList(scheduleMeeting.id, 'userId0');
 			});
 
-			const { waitingList } = result.current.meetings[temporaryRoom.id];
+			const { waitingList } = result.current.meetings[scheduleMeeting.id];
 			expect(waitingList).not.toBeNull();
 			expect(size(waitingList)).toBe(1);
 			expect(waitingList).toContain('userId1');
@@ -213,7 +213,7 @@ describe('Test components slice', () => {
 				result.current.removeUserFromWaitingList(scheduleMeeting.id, 'userId2');
 			});
 
-			const { waitingList } = result.current.meetings[temporaryRoom.id];
+			const { waitingList } = result.current.meetings[scheduleMeeting.id];
 			expect(waitingList).not.toBeNull();
 			expect(size(waitingList)).toBe(2);
 			expect(waitingList).toContain('userId0');
@@ -234,7 +234,7 @@ describe('Test components slice', () => {
 				);
 			});
 
-			const { recStartedAt, recUserId } = result.current.meetings[scheduleMeeting.roomId];
+			const { recStartedAt, recUserId } = result.current.meetings[scheduleMeeting.id];
 			expect(recStartedAt).toBe('2022-08-25T18:24:28.961+02:00');
 			expect(recUserId).toBe('userId0');
 		});
@@ -246,7 +246,7 @@ describe('Test components slice', () => {
 				result.current.stopRecording(scheduleMeeting.id);
 			});
 
-			const { recStartedAt, recUserId } = result.current.meetings[scheduleMeeting.roomId];
+			const { recStartedAt, recUserId } = result.current.meetings[scheduleMeeting.id];
 			expect(recStartedAt).toBeUndefined();
 			expect(recUserId).toBeUndefined();
 		});

--- a/src/store/slices/MeetingsStoreSlice.ts
+++ b/src/store/slices/MeetingsStoreSlice.ts
@@ -15,6 +15,18 @@ import { MeetingParticipant, MeetingParticipantMap } from '../../types/store/Mee
 import { MeetingsSlice, RootStore } from '../../types/store/StoreTypes';
 import { dateToISODate } from '../../utils/dateUtils';
 
+const mapParticipants = (participants: MeetingParticipantBe[]): MeetingParticipantMap =>
+	participants.reduce((acc: MeetingParticipantMap, participant: MeetingParticipantBe) => {
+		acc[participant.userId] = {
+			userId: participant.userId,
+			audioStreamOn: participant.audioStreamEnabled || false,
+			videoStreamOn: participant.videoStreamEnabled || false,
+			screenStreamOn: participant.screenStreamEnabled || false,
+			joinedAt: participant.joinedAt
+		};
+		return acc;
+	}, {});
+
 export const useMeetingsStoreSlice: StateCreator<
 	RootStore,
 	[['zustand/devtools', never]],
@@ -22,31 +34,16 @@ export const useMeetingsStoreSlice: StateCreator<
 	MeetingsSlice
 > = (set, get) => ({
 	meetings: {},
-	setMeetings: (meetings: MeetingBe[]): void => {
+	addMeetings: (meetings: MeetingBe[]): void => {
 		set(
 			produce((draft: RootStore) => {
 				forEach(meetings, (meeting) => {
-					// Create a map of participants instead of an array
-					const participantsMap: MeetingParticipantMap = meeting.participants.reduce(
-						(acc: MeetingParticipantMap, participant: MeetingParticipantBe) => {
-							acc[participant.userId] = {
-								userId: participant.userId,
-								audioStreamOn: participant.audioStreamEnabled || false,
-								videoStreamOn: participant.videoStreamEnabled || false,
-								screenStreamOn: participant.screenStreamEnabled || false,
-								joinedAt: participant.joinedAt
-							};
-							return acc;
-						},
-						{}
-					);
-
 					draft.meetings[meeting.roomId] = {
 						id: meeting.id,
 						name: meeting.name,
 						roomId: meeting.roomId,
 						active: meeting.active,
-						participants: participantsMap,
+						participants: mapParticipants(meeting.participants),
 						createdAt: meeting.createdAt,
 						meetingType: meeting.meetingType,
 						startedAt: meeting.startedAt,
@@ -62,48 +59,7 @@ export const useMeetingsStoreSlice: StateCreator<
 				});
 			}),
 			false,
-			'MEETINGS/SET_MEETINGS'
-		);
-	},
-	addMeeting: (meeting: MeetingBe): void => {
-		set(
-			produce((draft: RootStore) => {
-				// Create a map of participants instead of an array
-				const participantsMap: MeetingParticipantMap = meeting.participants.reduce(
-					(acc: MeetingParticipantMap, participant: MeetingParticipantBe) => {
-						acc[participant.userId] = {
-							userId: participant.userId,
-							audioStreamOn: participant.audioStreamEnabled || false,
-							videoStreamOn: participant.videoStreamEnabled || false,
-							screenStreamOn: participant.screenStreamEnabled || false,
-							joinedAt: participant.joinedAt
-						};
-						return acc;
-					},
-					{}
-				);
-				draft.meetings[meeting.roomId] = {
-					...draft.meetings[meeting.roomId],
-					id: meeting.id,
-					name: meeting.name,
-					roomId: meeting.roomId,
-					active: meeting.active,
-					participants: participantsMap,
-					createdAt: meeting.createdAt,
-					meetingType: meeting.meetingType,
-					startedAt: meeting.startedAt,
-					recStartedAt: meeting.recStartedAt,
-					recUserId: meeting.recUserId
-				};
-
-				// Set meetingId on room data
-				draft.rooms[meeting.roomId] = {
-					...draft.rooms[meeting.roomId],
-					meetingId: meeting.id
-				};
-			}),
-			false,
-			'MEETINGS/ADD'
+			'MEETINGS/ADD_MEETINGS'
 		);
 	},
 	deleteMeeting: (meetingId: string): void => {

--- a/src/store/slices/MeetingsStoreSlice.ts
+++ b/src/store/slices/MeetingsStoreSlice.ts
@@ -6,13 +6,17 @@
 /* eslint-disable no-param-reassign */
 
 import { produce } from 'immer';
-import { find, forEach, includes } from 'lodash';
+import { forEach, includes } from 'lodash';
 import { StateCreator } from 'zustand';
 
 import { MeetingBe, MeetingParticipantBe } from '../../types/network/models/meetingBeTypes';
 import { STREAM_TYPE } from '../../types/store/ActiveMeetingTypes';
-import { MeetingParticipant, MeetingParticipantMap } from '../../types/store/MeetingTypes';
-import { MeetingsSlice, RootStore } from '../../types/store/StoreTypes';
+import {
+	MeetingParticipant,
+	MeetingParticipantMap,
+	MeetingsSlice
+} from '../../types/store/MeetingTypes';
+import { RootStore } from '../../types/store/StoreTypes';
 import { dateToISODate } from '../../utils/dateUtils';
 
 const mapParticipants = (participants: MeetingParticipantBe[]): MeetingParticipantMap =>
@@ -38,7 +42,7 @@ export const useMeetingsStoreSlice: StateCreator<
 		set(
 			produce((draft: RootStore) => {
 				forEach(meetings, (meeting) => {
-					draft.meetings[meeting.roomId] = {
+					draft.meetings[meeting.id] = {
 						id: meeting.id,
 						name: meeting.name,
 						roomId: meeting.roomId,
@@ -65,10 +69,7 @@ export const useMeetingsStoreSlice: StateCreator<
 	deleteMeeting: (meetingId: string): void => {
 		set(
 			produce((draft: RootStore) => {
-				const meeting = find(draft.meetings, (meeting) => meeting.id === meetingId);
-				if (meeting) {
-					delete draft.meetings[meeting.roomId];
-				}
+				delete draft.meetings[meetingId];
 			}),
 			false,
 			'MEETINGS/DELETE'
@@ -77,10 +78,10 @@ export const useMeetingsStoreSlice: StateCreator<
 	startMeeting: (meetingId: string, startedAt: string): void => {
 		set(
 			produce((draft: RootStore) => {
-				const meeting = find(draft.meetings, (meeting) => meeting.id === meetingId);
+				const meeting = draft.meetings[meetingId];
 				if (meeting) {
-					draft.meetings[meeting.roomId].active = true;
-					draft.meetings[meeting.roomId].startedAt = startedAt;
+					meeting.active = true;
+					meeting.startedAt = startedAt;
 				}
 			}),
 			false,
@@ -90,10 +91,10 @@ export const useMeetingsStoreSlice: StateCreator<
 	stopMeeting: (meetingId: string): void => {
 		set(
 			produce((draft: RootStore) => {
-				const meeting = find(draft.meetings, (meeting) => meeting.id === meetingId);
+				const meeting = draft.meetings[meetingId];
 				if (meeting) {
-					draft.meetings[meeting.roomId].active = false;
-					draft.meetings[meeting.roomId].startedAt = undefined;
+					meeting.active = false;
+					meeting.startedAt = undefined;
 				}
 			}),
 			false,
@@ -104,7 +105,7 @@ export const useMeetingsStoreSlice: StateCreator<
 		set(
 			produce((draft: RootStore) => {
 				// Add participant only if components exists and sessionId isn't already on components
-				const meeting = find(draft.meetings, (meeting) => meeting.id === meetingId);
+				const meeting = draft.meetings[meetingId];
 				if (meeting) {
 					meeting.participants[participant.userId] = {
 						userId: participant.userId,
@@ -123,9 +124,9 @@ export const useMeetingsStoreSlice: StateCreator<
 		set(
 			produce((draft: RootStore) => {
 				// Add participant only if components exists and sessionId isn't already on components
-				const meeting = find(draft.meetings, (meeting) => meeting.id === meetingId);
+				const meeting = draft.meetings[meetingId];
 				if (meeting) {
-					delete draft.meetings[meeting.roomId].participants[userId];
+					delete meeting.participants[userId];
 				}
 			}),
 			false,
@@ -140,18 +141,18 @@ export const useMeetingsStoreSlice: StateCreator<
 	): void => {
 		set(
 			produce((draft: RootStore) => {
-				const meeting = find(draft.meetings, (meeting) => meeting.id === meetingId);
+				const meeting = draft.meetings[meetingId];
 				if (meeting) {
 					switch (streamType) {
 						case STREAM_TYPE.AUDIO:
-							draft.meetings[meeting.roomId].participants[userId].audioStreamOn = status;
+							meeting.participants[userId].audioStreamOn = status;
 							break;
 						case STREAM_TYPE.VIDEO:
-							draft.meetings[meeting.roomId].participants[userId].videoStreamOn = status;
+							meeting.participants[userId].videoStreamOn = status;
 							break;
 						case STREAM_TYPE.SCREEN:
-							draft.meetings[meeting.roomId].participants[userId].screenStreamOn = status;
-							draft.meetings[meeting.roomId].participants[userId].dateScreenOn = status
+							meeting.participants[userId].screenStreamOn = status;
+							meeting.participants[userId].dateScreenOn = status
 								? dateToISODate(Date.now())
 								: undefined;
 							break;
@@ -171,9 +172,9 @@ export const useMeetingsStoreSlice: StateCreator<
 	setWaitingList: (meetingId: string, waitingList: string[]): void => {
 		set(
 			produce((draft: RootStore) => {
-				const meeting = find(draft.meetings, (meeting) => meeting.id === meetingId);
+				const meeting = draft.meetings[meetingId];
 				if (meeting) {
-					draft.meetings[meeting.roomId].waitingList = waitingList;
+					meeting.waitingList = waitingList;
 				}
 			}),
 			false,
@@ -183,29 +184,29 @@ export const useMeetingsStoreSlice: StateCreator<
 	addUserToWaitingList: (meetingId: string, userId: string): void => {
 		set(
 			produce((draft: RootStore) => {
-				const meeting = find(draft.meetings, (meeting) => meeting.id === meetingId);
+				const meeting = draft.meetings[meetingId];
+				meeting.waitingList ??= [];
 				if (meeting && !includes(meeting.waitingList, userId)) {
-					if (!meeting.waitingList) draft.meetings[meeting.roomId].waitingList = [];
-					draft.meetings[meeting.roomId].waitingList?.push(userId);
+					draft.meetings[meeting.id].waitingList?.push(userId);
 				}
 			}),
 			false,
-			'AM/ADD_USER_TO_WAITING_LIST'
+			'AM/ADD_TO_WAITING_LIST'
 		);
 	},
 	removeUserFromWaitingList: (meetingId: string, userId: string): void => {
 		set(
 			produce((draft: RootStore) => {
-				const meeting = find(draft.meetings, (meeting) => meeting.id === meetingId);
+				const meeting = draft.meetings[meetingId];
 				if (meeting) {
-					const index = draft.meetings[meeting.roomId].waitingList?.indexOf(userId);
+					const index = meeting.waitingList?.indexOf(userId);
 					if (index !== undefined && index !== -1) {
-						draft.meetings[meeting.roomId].waitingList?.splice(index, 1);
+						meeting.waitingList?.splice(index, 1);
 					}
 				}
 			}),
 			false,
-			'AM/REMOVE_USER_FROM_WAITING_LIST'
+			'AM/REMOVE_FROM_WAITING_LIST'
 		);
 	},
 	startRecording: (
@@ -215,10 +216,10 @@ export const useMeetingsStoreSlice: StateCreator<
 	): void => {
 		set(
 			produce((draft: RootStore) => {
-				const meeting = find(draft.meetings, (meeting) => meeting.id === meetingId);
+				const meeting = draft.meetings[meetingId];
 				if (meeting) {
-					draft.meetings[meeting.roomId].recStartedAt = startRecordingTimestamp;
-					draft.meetings[meeting.roomId].recUserId = startRecordingUserId;
+					meeting.recStartedAt = startRecordingTimestamp;
+					meeting.recUserId = startRecordingUserId;
 				}
 			}),
 			false,
@@ -228,10 +229,10 @@ export const useMeetingsStoreSlice: StateCreator<
 	stopRecording: (meetingId: string): void => {
 		set(
 			produce((draft: RootStore) => {
-				const meeting = find(draft.meetings, (meeting) => meeting.id === meetingId);
+				const meeting = draft.meetings[meetingId];
 				if (meeting) {
-					draft.meetings[meeting.roomId].recStartedAt = undefined;
-					draft.meetings[meeting.roomId].recUserId = undefined;
+					meeting.recStartedAt = undefined;
+					meeting.recUserId = undefined;
 				}
 			}),
 			false,

--- a/src/store/slices/MeetingsStoreSlice.ts
+++ b/src/store/slices/MeetingsStoreSlice.ts
@@ -6,7 +6,7 @@
 /* eslint-disable no-param-reassign */
 
 import { produce } from 'immer';
-import { forEach, includes } from 'lodash';
+import { forEach, includes, remove } from 'lodash';
 import { StateCreator } from 'zustand';
 
 import { MeetingBe, MeetingParticipantBe } from '../../types/network/models/meetingBeTypes';
@@ -104,7 +104,6 @@ export const useMeetingsStoreSlice: StateCreator<
 	addParticipant: (meetingId: string, participant: MeetingParticipant): void => {
 		set(
 			produce((draft: RootStore) => {
-				// Add participant only if components exists and sessionId isn't already on components
 				const meeting = draft.meetings[meetingId];
 				if (meeting) {
 					meeting.participants[participant.userId] = {
@@ -123,7 +122,6 @@ export const useMeetingsStoreSlice: StateCreator<
 	removeParticipant: (meetingId: string, userId: string): void => {
 		set(
 			produce((draft: RootStore) => {
-				// Add participant only if components exists and sessionId isn't already on components
 				const meeting = draft.meetings[meetingId];
 				if (meeting) {
 					delete meeting.participants[userId];
@@ -152,9 +150,9 @@ export const useMeetingsStoreSlice: StateCreator<
 							break;
 						case STREAM_TYPE.SCREEN:
 							meeting.participants[userId].screenStreamOn = status;
-							meeting.participants[userId].dateScreenOn = status
-								? dateToISODate(Date.now())
-								: undefined;
+							if (status) {
+								meeting.participants[userId].dateScreenOn = dateToISODate(Date.now());
+							}
 							break;
 						default:
 							break;
@@ -178,7 +176,7 @@ export const useMeetingsStoreSlice: StateCreator<
 				}
 			}),
 			false,
-			'AM/SET_WAITING_LIST'
+			'MEETINGS/SET_WAITING_LIST'
 		);
 	},
 	addUserToWaitingList: (meetingId: string, userId: string): void => {
@@ -191,7 +189,7 @@ export const useMeetingsStoreSlice: StateCreator<
 				}
 			}),
 			false,
-			'AM/ADD_TO_WAITING_LIST'
+			'MEETINGS/ADD_TO_WAITING_LIST'
 		);
 	},
 	removeUserFromWaitingList: (meetingId: string, userId: string): void => {
@@ -199,14 +197,11 @@ export const useMeetingsStoreSlice: StateCreator<
 			produce((draft: RootStore) => {
 				const meeting = draft.meetings[meetingId];
 				if (meeting) {
-					const index = meeting.waitingList?.indexOf(userId);
-					if (index !== undefined && index !== -1) {
-						meeting.waitingList?.splice(index, 1);
-					}
+					remove(meeting.waitingList || [], (user) => user === userId);
 				}
 			}),
 			false,
-			'AM/REMOVE_FROM_WAITING_LIST'
+			'MEETINGS/REMOVE_FROM_WAITING_LIST'
 		);
 	},
 	startRecording: (
@@ -223,7 +218,7 @@ export const useMeetingsStoreSlice: StateCreator<
 				}
 			}),
 			false,
-			'AM/START_RECORDING'
+			'MEETINGS/START_RECORDING'
 		);
 	},
 	stopRecording: (meetingId: string): void => {
@@ -236,7 +231,7 @@ export const useMeetingsStoreSlice: StateCreator<
 				}
 			}),
 			false,
-			'AM/STOP_RECORDING'
+			'MEETINGS/STOP_RECORDING'
 		);
 	}
 });

--- a/src/store/slices/RoomsStoreSlice.ts
+++ b/src/store/slices/RoomsStoreSlice.ts
@@ -14,6 +14,7 @@ import { MessageType } from '../../types/store/ChatsRegistryTypes';
 import { Room, RoomsStoreSlice, RoomType } from '../../types/store/RoomTypes';
 import { RootStore } from '../../types/store/StoreTypes';
 import { dateToISODate, isBefore } from '../../utils/dateUtils';
+import { getMeetingIdFromRoom } from '../selectors/RoomsSelectors';
 
 export const useRoomsStoreSlice: StateCreator<
 	RootStore,
@@ -59,8 +60,10 @@ export const useRoomsStoreSlice: StateCreator<
 			produce((draft: RootStore) => {
 				delete draft.rooms[roomId];
 				delete draft.activeConversations[roomId];
-				delete draft.meetings[roomId];
 				delete draft.chatsRegistry[roomId];
+
+				const meetingId = getMeetingIdFromRoom(draft, roomId);
+				if (meetingId) delete draft.meetings[meetingId];
 			}),
 			false,
 			'ROOMS/REMOVE_ROOM'

--- a/src/types/store/MeetingTypes.ts
+++ b/src/types/store/MeetingTypes.ts
@@ -3,10 +3,33 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { MeetingType } from '../network/models/meetingBeTypes';
 
-export type MeetingsMap = {
-	[roomId: string]: Meeting;
+import { STREAM_TYPE } from './ActiveMeetingTypes';
+import { MeetingBe, MeetingType } from '../network/models/meetingBeTypes';
+
+export type MeetingsSlice = {
+	meetings: { [meetingId: string]: Meeting };
+	addMeetings: (meetings: MeetingBe[]) => void;
+	deleteMeeting: (meetingId: string) => void;
+	startMeeting: (meetingId: string, startedAt: string) => void;
+	stopMeeting: (meetingId: string) => void;
+	addParticipant: (meetingId: string, participant: MeetingParticipant) => void;
+	removeParticipant: (meetingId: string, userId: string) => void;
+	changeStreamStatus: (
+		meetingId: string,
+		userId: string,
+		stream: STREAM_TYPE,
+		status: boolean
+	) => void;
+	setWaitingList: (meetingId: string, waitingList: string[]) => void;
+	addUserToWaitingList: (meetingId: string, userId: string) => void;
+	removeUserFromWaitingList: (meetingId: string, userId: string) => void;
+	startRecording: (
+		meetingId: string,
+		startRecordingTimestamp: string,
+		startRecordingUserId: string
+	) => void;
+	stopRecording: (meetingId: string) => void;
 };
 
 export type Meeting = {

--- a/src/types/store/StoreTypes.ts
+++ b/src/types/store/StoreTypes.ts
@@ -25,8 +25,7 @@ import { MeetingBe } from '../network/models/meetingBeTypes';
 
 export type MeetingsSlice = {
 	meetings: MeetingsMap;
-	setMeetings: (meetings: MeetingBe[]) => void;
-	addMeeting: (meeting: MeetingBe) => void;
+	addMeetings: (meetings: MeetingBe[]) => void;
 	deleteMeeting: (meetingId: string) => void;
 	startMeeting: (meetingId: string, startedAt: string) => void;
 	stopMeeting: (meetingId: string) => void;

--- a/src/types/store/StoreTypes.ts
+++ b/src/types/store/StoreTypes.ts
@@ -17,36 +17,10 @@ import {
 } from './ActiveMeetingTypes';
 import { ChatsRegistryStoreSlice } from './ChatsRegistryTypes';
 import { ConnectionsStoreSlice } from './ConnectionsTypes';
-import { MeetingParticipant, MeetingsMap } from './MeetingTypes';
+import { MeetingsSlice } from './MeetingTypes';
 import { RoomsStoreSlice } from './RoomTypes';
 import { SessionStoreSlice } from './SessionTypes';
 import { UsersStoreSlice } from './UserTypes';
-import { MeetingBe } from '../network/models/meetingBeTypes';
-
-export type MeetingsSlice = {
-	meetings: MeetingsMap;
-	addMeetings: (meetings: MeetingBe[]) => void;
-	deleteMeeting: (meetingId: string) => void;
-	startMeeting: (meetingId: string, startedAt: string) => void;
-	stopMeeting: (meetingId: string) => void;
-	addParticipant: (meetingId: string, participant: MeetingParticipant) => void;
-	removeParticipant: (meetingId: string, userId: string) => void;
-	changeStreamStatus: (
-		meetingId: string,
-		userId: string,
-		stream: STREAM_TYPE,
-		status: boolean
-	) => void;
-	setWaitingList: (meetingId: string, waitingList: string[]) => void;
-	addUserToWaitingList: (meetingId: string, userId: string) => void;
-	removeUserFromWaitingList: (meetingId: string, userId: string) => void;
-	startRecording: (
-		meetingId: string,
-		startRecordingTimestamp: string,
-		startRecordingUserId: string
-	) => void;
-	stopRecording: (meetingId: string) => void;
-};
 
 export type ActiveMeetingSlice = {
 	activeMeeting: ActiveMeetingMap;


### PR DESCRIPTION
This PR introduces a refactor of `MeetingsStoreSlice.ts` with the following changes:

- Unified `setMeetings` and `addMeeting` into `addMeetings`: both were duplicating logic; now there’s a single shared implementation that accept an array of meetings
- Changed key in meetings map from `roomId` to `meetingId`:  it’s more appropriate for map keys to reflect the unique identifier of the object they store, rather than referencing a different related entity (room)
- Removed duplicated selectors (`getRoomIdFromMeeting`)
- Added missing tests