### PR TITLE
fix: select audio e video device before meeting

### DIFF
--- a/src/meetings/components/meetingAccessPoint/mediaHandlers/LocalMediaHandler.tsx
+++ b/src/meetings/components/meetingAccessPoint/mediaHandlers/LocalMediaHandler.tsx
@@ -207,9 +207,17 @@ const LocalMediaHandler: FC<LocalMediaHandlerProps> = ({
 
 	useEffect(() => {
 		if (selectedDevicesId.audio === undefined && mediaAudioList[0]) {
-			setSelectedDevicesId({ audio: mediaAudioList[0].value, video: selectedDevicesId.video });
+			const defaultDevice = find(mediaAudioList, ['value', 'default']) ?? mediaAudioList[0];
+			setSelectedDevicesId({ audio: defaultDevice.value, video: selectedDevicesId.video });
 		}
 	}, [mediaAudioList, selectedDevicesId, setSelectedDevicesId]);
+
+	useEffect(() => {
+		if (selectedDevicesId.video === undefined && mediaVideoList[0]) {
+			const defaultDevice = find(mediaVideoList, ['value', 'default']) ?? mediaVideoList[0];
+			setSelectedDevicesId({ audio: selectedDevicesId.audio, video: defaultDevice.value });
+		}
+	}, [mediaVideoList, selectedDevicesId.audio, selectedDevicesId.video, setSelectedDevicesId]);
 
 	useEffect(() => {
 		if (mediaDevicesEnabled.video && videoPermission === 'denied') {

--- a/src/meetings/components/meetingAccessPoint/useAccessMeetingAction.tsx
+++ b/src/meetings/components/meetingAccessPoint/useAccessMeetingAction.tsx
@@ -94,12 +94,12 @@ const useAccessMeetingAction = (
 			MeetingsApi.enterMeeting(
 				roomId,
 				{
-					videoStreamEnabled: mediaDevicesEnabled ? mediaDevicesEnabled.video : false,
-					audioStreamEnabled: mediaDevicesEnabled ? mediaDevicesEnabled.audio : false
+					videoStreamEnabled: !!mediaDevicesEnabled?.video,
+					audioStreamEnabled: !!mediaDevicesEnabled?.audio
 				},
 				{
-					audioDevice: selectedDevicesId ? selectedDevicesId.audio : undefined,
-					videoDevice: selectedDevicesId ? selectedDevicesId.video : undefined
+					audioDevice: selectedDevicesId?.audio,
+					videoDevice: selectedDevicesId?.video
 				}
 			)
 				.then((meetingId) => {
@@ -119,12 +119,12 @@ const useAccessMeetingAction = (
 			MeetingsApi.joinMeeting(
 				meetingId,
 				{
-					videoStreamEnabled: mediaDevicesEnabled ? mediaDevicesEnabled.video : false,
-					audioStreamEnabled: mediaDevicesEnabled ? mediaDevicesEnabled.audio : false
+					videoStreamEnabled: !!mediaDevicesEnabled?.video,
+					audioStreamEnabled: !!mediaDevicesEnabled?.audio
 				},
 				{
-					audioDevice: selectedDevicesId ? selectedDevicesId.audio : undefined,
-					videoDevice: selectedDevicesId ? selectedDevicesId.video : undefined
+					audioDevice: selectedDevicesId?.audio,
+					videoDevice: selectedDevicesId?.video
 				}
 			)
 				.then((resp) => {

--- a/src/store/slices/ActiveMeetingSlice.ts
+++ b/src/store/slices/ActiveMeetingSlice.ts
@@ -40,11 +40,11 @@ export const useActiveMeetingSlice: StateCreator<
 		meetingId: string,
 		audioStream?: {
 			enabled: boolean;
-			selectedDeviceId?: string;
+			deviceId?: string;
 		},
 		videoStream?: {
 			enabled: boolean;
-			selectedDeviceId?: string;
+			deviceId?: string;
 		}
 	): void => {
 		set(
@@ -54,19 +54,19 @@ export const useActiveMeetingSlice: StateCreator<
 					// Peer connections and streams
 					bidirectionalAudioConn: new BidirectionalConnectionAudioInOut(
 						meetingId,
-						audioStream?.enabled || false,
-						audioStream?.selectedDeviceId
+						!!audioStream?.enabled,
+						audioStream?.deviceId
 					),
 					videoScreenIn: new VideoScreenInConnection(meetingId),
 					videoOutConn: new VideoOutConnection(
 						meetingId,
-						videoStream?.enabled || false,
-						videoStream?.selectedDeviceId
+						!!videoStream?.enabled,
+						videoStream?.deviceId
 					),
 					screenOutConn: new ScreenOutConnection(meetingId),
 					localStreams: {
-						selectedAudioDeviceId: audioStream?.selectedDeviceId,
-						selectedVideoDeviceId: videoStream?.selectedDeviceId
+						selectedAudioDeviceId: audioStream?.deviceId,
+						selectedVideoDeviceId: videoStream?.deviceId
 					},
 					subscription: {},
 					// Default graphic values


### PR DESCRIPTION
Media devices selected before joining a meeting now match the ones used during the meeting.

Additionally, support for selecting the default system device in Chrome (deviceId: "default") has been implemented.