### PR TITLE
fix: unable to replace unsubscribed stream

### DIFF
--- a/src/network/webRTC/VideoScreenInConnection.ts
+++ b/src/network/webRTC/VideoScreenInConnection.ts
@@ -55,14 +55,17 @@ export default class VideoScreenInConnection implements IVideoScreenInConnection
 	}
 
 	public handleParticipantsSubscribed(streamsMap: StreamInfo[]): void {
+		const temporaryStreams: StreamMap = {};
 		forEach(streamsMap, (stream) => {
 			const streamsKey = `${stream.userId}-${stream.type.toLowerCase()}`;
-			this.streamsMap[streamsKey] = {
+			temporaryStreams[streamsKey] = {
 				...this.streamsMap[streamsKey],
 				userId: stream.userId,
 				type: stream.type.toLowerCase() as STREAM_TYPE
 			};
 		});
+
+		this.streamsMap = temporaryStreams;
 		this.updateStreams();
 	}
 


### PR DESCRIPTION
Fixed an issue where re-subscribing to a video stream after an unsubscribe left the video tile stuck in a pending state.

The problem was caused by the way `streamsMap` in `VideoScreenInConnection.ts` was updated: when a stream was unsubscribed, the entry remained in streamsMap and was never properly removed.

On re-subscription, the existing object inside the map was updated, but since only a nested object reference changed, the overall map was not replaced and no proper state update was triggered.