### PR TITLE
fix: avoid to call leaveConversation after leaveMeeting in virtual meeting [CO-2661]

### DIFF
--- a/src/MainApp.tsx
+++ b/src/MainApp.tsx
@@ -32,7 +32,7 @@ export default function MainApp(): React.JSX.Element {
 	const { prefs, attrs } = useUserSettings();
 
 	useEffect(() => {
-		setSupportedVersions(['1.6.2', '1.6.1', '1.6.0']);
+		setSupportedVersions(['1.6.3', '1.6.2', '1.6.1', '1.6.0']);
 	}, [setSupportedVersions]);
 
 	// STORE: init with user session main infos

--- a/src/network/API_VERSIONING.md
+++ b/src/network/API_VERSIONING.md
@@ -3,6 +3,13 @@
 This document tracks internal changes related to API versioning, renamed events, and modified files.
 
 ---
+## Version 1.6.3 (2025-09-31 - Released with Carbonio 25.12.0)
+### Changes
+- **API**: Virtual meeting external users do not have to call `leaveConversation` after `leaveMeeting`
+
+### Affected Files
+- 'src/network/apis/MeetingsApi.ts' on function `leaveMeeting`
+
 
 ## Version 1.6.2 (2025-08-08 - Released with Carbonio 25.9.0)
 ### Changes

--- a/src/network/apis/MeetingsApi.ts
+++ b/src/network/apis/MeetingsApi.ts
@@ -5,6 +5,7 @@
  */
 
 import { chain, find } from 'lodash';
+import { lte } from 'semver';
 
 import { getMeetingByRoomId } from '../../store/selectors/MeetingSelectors';
 import useStore from '../../store/Store';
@@ -167,8 +168,15 @@ class MeetingsApi implements IMeetingsApi {
 			.then((resp: LeaveMeetingResponse) => {
 				useStore.getState().meetingDisconnection(meetingId);
 
+				// DEPRECATED: This function exists for backward compatibility with previous versions.
+				//  * Remove once support for v1.6.2 is officially dropped.
 				// Leave temporary room when a member leaves the scheduled meeting
-				if (room?.type === RoomType.TEMPORARY && iAmNotOwner) {
+				const version = useStore.getState().session.apiVersion;
+				if (
+					(!version || lte(version, '1.6.2')) &&
+					room?.type === RoomType.TEMPORARY &&
+					iAmNotOwner
+				) {
 					RoomsApi.deleteRoomMember(room.id, useStore.getState().session.id ?? '');
 				}
 				if (isExternal) {


### PR DESCRIPTION
- [x] Wait versio 1.6.3 on `ws-collaboration` BE