### PR TITLE
refactor: change rooms data to improve initial loading performances [CO-3327]

### DIFF
--- a/src/MainApp.tsx
+++ b/src/MainApp.tsx
@@ -22,7 +22,6 @@ import { xmppClient } from './network/xmpp/XMPPClient';
 import WaitingListSnackbar from './settings/components/WaitingListSnackbar';
 import initSettings from './settings/initSettings';
 import useStore from './store/Store';
-import { UserType } from './types/store/UserTypes';
 import { setDateDefault } from './utils/dateUtils';
 
 export default function MainApp(): React.JSX.Element {
@@ -52,7 +51,11 @@ export default function MainApp(): React.JSX.Element {
 	useEffect(() => {
 		const userAccount = getUserAccount();
 		if (authenticated && userAccount) {
-			setLoginInfo(userAccount.id, userAccount.name, userAccount.displayName, UserType.INTERNAL);
+			setLoginInfo({
+				id: userAccount.id,
+				name: userAccount.name,
+				displayName: userAccount.displayName
+			});
 		}
 	}, [setLoginInfo, authenticated]);
 

--- a/src/chats/components/UserAvatar.test.tsx
+++ b/src/chats/components/UserAvatar.test.tsx
@@ -108,7 +108,7 @@ const meeting2: MeetingBe = createMockMeeting({
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo(user1Info.id, user1Info.name);
+	store.setLoginInfo({ id: user1Info.id, name: user1Info.name });
 	store.setUserInfo([user1Info, user2Info, user3Info]);
 	store.addRooms([
 		room,

--- a/src/chats/components/conversation/Chat.test.tsx
+++ b/src/chats/components/conversation/Chat.test.tsx
@@ -40,7 +40,7 @@ const mockedRoom: RoomBe = createMockRoom({
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo(user1.id, 'user1');
+	store.setLoginInfo({ id: user1.id, name: 'user1' });
 	store.setUserInfo([user1]);
 	store.addRooms([mockedRoom]);
 });

--- a/src/chats/components/conversation/Conversation.test.tsx
+++ b/src/chats/components/conversation/Conversation.test.tsx
@@ -69,7 +69,7 @@ vi.mock('../../../hooks/useMediaQueryCheck');
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo(user1Info.id, user1Info.email, user1Info.name);
+	store.setLoginInfo({ id: user1Info.id, name: user1Info.email, displayName: user1Info.name });
 	store.setUserInfo([user2Info]);
 	store.addRooms([testRoom, testRoom2]);
 });

--- a/src/chats/components/conversation/ConversationHeader.test.tsx
+++ b/src/chats/components/conversation/ConversationHeader.test.tsx
@@ -141,7 +141,7 @@ describe('Conversation header test', () => {
 
 beforeEach(() => {
 	const store: RootStore = useStore.getState();
-	store.setLoginInfo(mockPaoloUser.id, mockPaoloUser.name);
+	store.setLoginInfo({ id: mockPaoloUser.id, name: mockPaoloUser.name });
 	store.setUserInfo([mockRobertoUser, mockLucaUser, mockGianniUser, mockQuintoUser]);
 	store.addRooms([mockedRoom]);
 });

--- a/src/chats/components/conversation/MessagesList.test.tsx
+++ b/src/chats/components/conversation/MessagesList.test.tsx
@@ -343,7 +343,7 @@ describe('render list of messages with history loader visible for first time ope
 		const { result } = renderHook(() => useStore());
 		act(() => {
 			result.current.setUserInfo([user2Be]);
-			result.current.setLoginInfo(user1Be.id, user1Be.name);
+			result.current.setLoginInfo({ id: user1Be.id, name: user1Be.name });
 			result.current.setHistoryIsFullyLoaded(room.id);
 			result.current.updateHistory(room.id, [mockedConfigurationMessage]);
 			result.current.addCreateRoomMessage(room.id);
@@ -401,7 +401,7 @@ describe('render list of messages with history loader visible for first time ope
 beforeEach(() => {
 	const store = useStore.getState();
 	store.addRooms([room, mockedRoom]);
-	store.setLoginInfo('userId', 'User');
+	store.setLoginInfo({ id: 'userId', name: 'User' });
 	store.setUserInfo([userA, userB, userC]);
 });
 describe('Scroll position', () => {
@@ -440,7 +440,7 @@ describe('Display group of messages', () => {
 		]);
 		const { result } = renderHook(() => useStore());
 		act(() => {
-			result.current.setLoginInfo('userId', 'User');
+			result.current.setLoginInfo({ id: 'userId', name: 'User' });
 			result.current.addRooms([mockedRoom]);
 		});
 
@@ -470,7 +470,7 @@ describe('Display group of messages', () => {
 		]);
 		const { result } = renderHook(() => useStore());
 		act(() => {
-			result.current.setLoginInfo('userId', 'User');
+			result.current.setLoginInfo({ id: 'userId', name: 'User' });
 			result.current.setUserInfo([userA, userB, userC]);
 		});
 

--- a/src/chats/components/conversation/PinMessage.test.tsx
+++ b/src/chats/components/conversation/PinMessage.test.tsx
@@ -27,7 +27,7 @@ const oneToOneRoom: RoomBe = createMockRoom({
 });
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo(user1.id, 'user1');
+	store.setLoginInfo({ id: user1.id, name: 'user1' });
 	store.setUserInfo([user1, user2, user3]);
 	store.addRooms([oneToOneRoom]);
 });
@@ -78,7 +78,7 @@ describe('PinMessage', () => {
 
 		beforeEach(() => {
 			const store = useStore.getState();
-			store.setLoginInfo(user1.id, 'user1');
+			store.setLoginInfo({ id: user1.id, name: 'user1' });
 			store.setUserInfo([user1, user2, user3]);
 			store.addRooms([group]);
 		});
@@ -104,7 +104,7 @@ describe('PinMessage', () => {
 				from: 'user1'
 			});
 			const store = useStore.getState();
-			store.setLoginInfo(user2.id, 'user2');
+			store.setLoginInfo({ id: user2.id, name: 'user2' });
 
 			setup(<PinMessage pinnedMessage={mockedTextMessage} />);
 

--- a/src/chats/components/conversation/footer/ConversationFooter.test.tsx
+++ b/src/chats/components/conversation/footer/ConversationFooter.test.tsx
@@ -92,7 +92,7 @@ const draftMessage = 'I am a draft message';
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo('idPaolo', 'Paolo');
+	store.setLoginInfo({ id: 'idPaolo', name: 'Paolo' });
 	store.addRooms([mockedRoom]);
 });
 
@@ -470,7 +470,7 @@ describe('Send message', () => {
 	test("attachment selector shouldn't be present if the user is a guest", () => {
 		const store = useStore.getState();
 		store.addRooms([mockedRoomTemporary]);
-		store.setLoginInfo(guestUser.id, guestUser.name, guestUser.type);
+		store.setLoginInfo({ id: guestUser.id, name: guestUser.name, userType: guestUser.type });
 		store.setUserInfo([guestUser]);
 		setup(<ConversationFooter roomId={mockedRoom.id} />);
 

--- a/src/chats/components/conversation/footer/ConversationFooter.test.tsx
+++ b/src/chats/components/conversation/footer/ConversationFooter.test.tsx
@@ -79,6 +79,7 @@ const storeSetupAdvanced = (): { user: UserEvent; store: RootStore } => {
 const storeSetupGroup = (): { user: UserEvent; store: RootStore } => {
 	const store = useStore.getState();
 	store.setAttributes(createMockAttributesList({ carbonioWscMessageEditTimeLimit: '5m' }));
+	store.setInboxMessages([mockedMessage]);
 	store.newMessage(mockedMessage);
 	const { user } = setup(<ConversationFooter roomId={mockedRoom.id} />);
 	return { user, store };
@@ -828,7 +829,7 @@ describe('Draft message', () => {
 			roomId: mockedRoom.id,
 			date: Date.now()
 		});
-		act(() => store.newMessage(messageByRoberto));
+		act(() => store.setInboxMessages([messageByRoberto]));
 
 		await user.keyboard('{ArrowUp}');
 

--- a/src/chats/components/conversation/footer/MessageComposer.tsx
+++ b/src/chats/components/conversation/footer/MessageComposer.tsx
@@ -39,7 +39,7 @@ import {
 	getFilesToUploadArray,
 	getReferenceMessage
 } from '../../../../store/selectors/ActiveConversationsSelectors';
-import { getLastMessageIdSelector } from '../../../../store/selectors/ChatsRegistrySelectors';
+import { getLastMessageSelector } from '../../../../store/selectors/ChatsRegistrySelectors';
 import { getAttribute, getUserId } from '../../../../store/selectors/SessionSelectors';
 import { getIsUserGuest } from '../../../../store/selectors/UsersSelectors';
 import useStore from '../../../../store/Store';
@@ -48,7 +48,7 @@ import {
 	messageActionType,
 	ReferenceMessage
 } from '../../../../types/store/ActiveConversationTypes';
-import { Message, MessageType, TextMessage } from '../../../../types/store/ChatsRegistryTypes';
+import { MessageType, TextMessage } from '../../../../types/store/ChatsRegistryTypes';
 import { getImageSize, isAttachmentImage } from '../../../../utils/attachmentUtils';
 import { BrowserUtils } from '../../../../utils/BrowserUtils';
 import { canPerformAction } from '../../../../utils/MessageActionsUtils';
@@ -99,13 +99,10 @@ const MessageComposer: React.FC<ConversationMessageComposerProps> = ({
 	const removeFilesToAttach = useStore((store) => store.removeFilesToAttach);
 	const setFileDescription = useStore((store) => store.setFileDescription);
 	const filesToUploadArray = useStore((store) => getFilesToUploadArray(store, roomId));
-	const lastMessageId: string | undefined = useStore((state) =>
-		getLastMessageIdSelector(state, roomId)
-	);
 	const messageEditTimeLimit = useStore((store) =>
 		getAttribute(store, 'messageEditTimeLimit')
 	) as number;
-	const lastMessageOfRoom: Message | undefined = useMessage(roomId, lastMessageId ?? '');
+	const lastMessageOfRoom = useStore((state) => getLastMessageSelector(state, roomId));
 	const setReferenceMessage = useStore((store) => store.setReferenceMessage);
 	const maxAttachmentSize = useStore((store) => getAttribute(store, 'maxAttachmentSize'));
 

--- a/src/chats/components/conversation/footer/MessageReferenceDisplayed.test.tsx
+++ b/src/chats/components/conversation/footer/MessageReferenceDisplayed.test.tsx
@@ -81,7 +81,7 @@ const attachmentTextMessage = createMockTextMessage({
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo(loggedUser.id, loggedUser.name);
+	store.setLoginInfo({ id: loggedUser.id, name: loggedUser.name });
 	store.setUserInfo([loggedUser, user1, forwardedUser]);
 	store.addRooms([mockedRoom]);
 });

--- a/src/chats/components/conversation/forwardModal/ForwardMessageModal.test.tsx
+++ b/src/chats/components/conversation/forwardModal/ForwardMessageModal.test.tsx
@@ -44,7 +44,7 @@ vi.mock('../../../../hooks/useRouting');
 
 beforeEach(() => {
 	const store: RootStore = useStore.getState();
-	store.setLoginInfo(sessionUser.id, sessionUser.name);
+	store.setLoginInfo({ id: sessionUser.id, name: sessionUser.name });
 	store.setUserInfo([user1]);
 	store.addRooms([testRoom, chat, chat2, chat3]);
 });

--- a/src/chats/components/conversation/messageBubbles/Bubble.test.tsx
+++ b/src/chats/components/conversation/messageBubbles/Bubble.test.tsx
@@ -166,7 +166,7 @@ const mockedTextMessagePending = createMockTextMessage({
 beforeEach(() => {
 	const store: RootStore = useStore.getState();
 	store.addRooms([mockedRoom, mockedTempRoom]);
-	store.setLoginInfo(user1Be.id, user1Be.name);
+	store.setLoginInfo({ id: user1Be.id, name: user1Be.name });
 	store.setUserInfo([guestUser, user1Be]);
 	store.setAttributes(createMockAttributesList({ carbonioWscMessageDeleteTimeLimit: '5m' }));
 });
@@ -247,7 +247,7 @@ describe('Attachment footer', () => {
 	test.each(readsMessages)('Display message sent from me, %s', (format, msg, cap, iconToCheck) => {
 		const store: RootStore = useStore.getState();
 		store.newMessage(msg);
-		store.setLoginInfo(user1Be.id, user1Be.name);
+		store.setLoginInfo({ id: user1Be.id, name: user1Be.name });
 		store.setAttributes(
 			createMockAttributesList({ carbonioWscShowMessageReads: cap ? 'TRUE' : 'FALSE' })
 		);
@@ -265,7 +265,7 @@ describe('Attachment footer', () => {
 	test('Display reads for a message sent from me, me - user cannot see reads', () => {
 		const store: RootStore = useStore.getState();
 		store.newMessage(mockedTextMessageSentByMe);
-		store.setLoginInfo(user1Be.id, user1Be.name);
+		store.setLoginInfo({ id: user1Be.id, name: user1Be.name });
 		store.setAttributes(createMockAttributesList({ carbonioWscShowMessageReads: 'FALSE' }));
 		setup(
 			<Bubble
@@ -280,7 +280,7 @@ describe('Attachment footer', () => {
 	test('Display unread message sent from me - user cannot see reads', () => {
 		const store: RootStore = useStore.getState();
 		store.newMessage(mockedTextMessageUnread);
-		store.setLoginInfo(user1Be.id, user1Be.name);
+		store.setLoginInfo({ id: user1Be.id, name: user1Be.name });
 		store.setAttributes(createMockAttributesList({ carbonioWscShowMessageReads: 'FALSE' }));
 		setup(
 			<Bubble

--- a/src/chats/components/conversation/messageBubbles/MessageReactionsList.test.tsx
+++ b/src/chats/components/conversation/messageBubbles/MessageReactionsList.test.tsx
@@ -70,7 +70,7 @@ const reactionChipTestId = 'reaction-chip';
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo(loggedUser.id, loggedUser.name);
+	store.setLoginInfo({ id: loggedUser.id, name: loggedUser.name });
 	store.setUserInfo([loggedUser, user1, user2, user3]);
 	store.addRooms([room]);
 	store.newMessage(simpleTextMessage);

--- a/src/chats/components/conversation/messageBubbles/ReactionChip.test.tsx
+++ b/src/chats/components/conversation/messageBubbles/ReactionChip.test.tsx
@@ -21,7 +21,7 @@ const user3 = createMockUser({ id: 'user3', name: 'User 3' });
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo(loggedUser.id, loggedUser.name);
+	store.setLoginInfo({ id: loggedUser.id, name: loggedUser.name });
 	store.setUserInfo([loggedUser, user1, user2, user3]);
 });
 

--- a/src/chats/components/conversation/messageBubbles/bubbleActions/useBubbleReactions.test.tsx
+++ b/src/chats/components/conversation/messageBubbles/bubbleActions/useBubbleReactions.test.tsx
@@ -40,7 +40,7 @@ const iconTestId = 'icon: SmileOutline';
 
 beforeEach(() => {
 	const store: RootStore = useStore.getState();
-	store.setLoginInfo(sessionUser.id, sessionUser.name);
+	store.setLoginInfo({ id: sessionUser.id, name: sessionUser.name });
 	store.addRooms([room]);
 	store.newMessage(simpleTextMessage);
 });

--- a/src/chats/components/conversation/messageBubbles/readByPopoverList/ReadByPopoverList.test.tsx
+++ b/src/chats/components/conversation/messageBubbles/readByPopoverList/ReadByPopoverList.test.tsx
@@ -60,7 +60,7 @@ const ComplexComponent = (): ReactElement => {
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo(sessionUser.id, sessionUser.email);
+	store.setLoginInfo({ id: sessionUser.id, name: sessionUser.email });
 	store.setUserInfo([user1, user2]);
 	store.newMessage(textMessage);
 	store.updateReadStatus(room.id, [user1Marker]);

--- a/src/chats/components/conversation/useFirstUnreadMessage.test.tsx
+++ b/src/chats/components/conversation/useFirstUnreadMessage.test.tsx
@@ -92,7 +92,7 @@ const complexHistory = [
 describe('useFirstUnreadMessage with text messages', () => {
 	beforeEach(() => {
 		const store = useStore.getState();
-		store.setLoginInfo(myUserId, 'User');
+		store.setLoginInfo({ id: myUserId });
 		store.addRooms([room]);
 		store.updateHistory(room.id, textHistory);
 	});
@@ -146,7 +146,7 @@ describe('useFirstUnreadMessage with text messages', () => {
 describe('useFirstUnreadMessage with all types of messages', () => {
 	beforeEach(() => {
 		const store = useStore.getState();
-		store.setLoginInfo(myUserId, 'User');
+		store.setLoginInfo({ id: myUserId });
 		store.addRooms([room]);
 		store.updateHistory(room.id, complexHistory);
 	});

--- a/src/chats/components/infoPanel/conversationActionsAccordion/ActionsAccordion.test.tsx
+++ b/src/chats/components/infoPanel/conversationActionsAccordion/ActionsAccordion.test.tsx
@@ -45,7 +45,7 @@ const user3Be: UserBe = createMockUser({
 beforeEach(() => {
 	const store = useStore.getState();
 	store.setUserInfo([user1Be, user2Be, user3Be]);
-	store.setLoginInfo(user1Be.id, user1Be.name);
+	store.setLoginInfo({ id: user1Be.id, name: user1Be.name });
 });
 
 describe('Actions Accordion', () => {

--- a/src/chats/components/infoPanel/conversationActionsAccordion/AddNewMemberAction.test.tsx
+++ b/src/chats/components/infoPanel/conversationActionsAccordion/AddNewMemberAction.test.tsx
@@ -56,7 +56,7 @@ vi.mock('../../../../network/soap/SearchUsersByFeatureRequest');
 beforeEach(() => {
 	const store = useStore.getState();
 	store.addRooms([mockedRoom]);
-	store.setLoginInfo(user1Info.id, user1Info.name);
+	store.setLoginInfo({ id: user1Info.id, name: user1Info.name });
 	store.setUserInfo([user2Info]);
 	store.setAttributes(createMockAttributesList({ carbonioWscMaxGroupMembers: '5' }));
 });

--- a/src/chats/components/infoPanel/conversationActionsAccordion/ClearHistoryAction.test.tsx
+++ b/src/chats/components/infoPanel/conversationActionsAccordion/ClearHistoryAction.test.tsx
@@ -51,7 +51,7 @@ describe('clear history action', () => {
 		const { result } = renderHook(() => useStore());
 		act(() => {
 			result.current.addRooms([mockedRoom]);
-			result.current.setLoginInfo(user1Info.id, user1Info.name);
+			result.current.setLoginInfo({ id: user1Info.id, name: user1Info.name });
 			result.current.setUserInfo([user1Info, user2Info]);
 			result.current.newMessage(message);
 		});

--- a/src/chats/components/infoPanel/conversationActionsAccordion/ClearHistoryModal.tsx
+++ b/src/chats/components/infoPanel/conversationActionsAccordion/ClearHistoryModal.tsx
@@ -12,7 +12,7 @@ import { useTranslation } from 'react-i18next';
 import { clearRoomHistory } from '../../../../network';
 import { xmppClient } from '../../../../network/xmpp/XMPPClient';
 import {
-	getLastTextMessageIdSelector,
+	getLastMessageSelector,
 	getRoomUnreadSelector
 } from '../../../../store/selectors/ChatsRegistrySelectors';
 import useStore from '../../../../store/Store';
@@ -40,19 +40,17 @@ const ClearHistoryModal: FC<ClearHistoryModalProps> = ({
 	const closeLabel = t('action.close', 'Close');
 
 	const unreadMessagesCount = useStore((store) => getRoomUnreadSelector(store, roomId));
-	const lastTextMessageId: string | undefined = useStore((state) =>
-		getLastTextMessageIdSelector(state, roomId)
-	);
+	const lastTextMessage = useStore((state) => getLastMessageSelector(state, roomId));
 
 	const clearHistory = useCallback(() => {
-		if (unreadMessagesCount > 0 && lastTextMessageId) {
-			xmppClient.readMessage(roomId, lastTextMessageId);
+		if (unreadMessagesCount > 0 && lastTextMessage) {
+			xmppClient.readMessage(roomId, lastTextMessage.id);
 		}
 		clearRoomHistory(roomId).then(() => {
 			successfulSnackbar();
 			closeModal();
 		});
-	}, [closeModal, lastTextMessageId, roomId, successfulSnackbar, unreadMessagesCount]);
+	}, [closeModal, lastTextMessage, roomId, successfulSnackbar, unreadMessagesCount]);
 
 	return (
 		<Modal

--- a/src/chats/components/infoPanel/conversationActionsAccordion/DeleteConversationAction.test.tsx
+++ b/src/chats/components/infoPanel/conversationActionsAccordion/DeleteConversationAction.test.tsx
@@ -66,7 +66,7 @@ vi.mock('../../../../hooks/useRouting');
 beforeEach(() => {
 	const store: RootStore = useStore.getState();
 	store.addRooms([testRoom2]);
-	store.setLoginInfo(user1Info.id, user1Info.name);
+	store.setLoginInfo({ id: user1Info.id, name: user1Info.name });
 	store.setUserInfo([user1Info, user2Info]);
 });
 

--- a/src/chats/components/infoPanel/conversationActionsAccordion/EditConversationAction.test.tsx
+++ b/src/chats/components/infoPanel/conversationActionsAccordion/EditConversationAction.test.tsx
@@ -51,7 +51,7 @@ const testRoom2: RoomBe = createMockRoom({
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo(user1Info.id, user1Info.name);
+	store.setLoginInfo({ id: user1Info.id, name: user1Info.name });
 	store.setUserInfo([user1Info, user2Info]);
 	store.addRooms([testRoom, testRoom2]);
 });

--- a/src/chats/components/infoPanel/conversationActionsAccordion/LeaveConversationAction.test.tsx
+++ b/src/chats/components/infoPanel/conversationActionsAccordion/LeaveConversationAction.test.tsx
@@ -34,7 +34,7 @@ vi.mock('../../../../hooks/useRouting');
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo(user2Info.id, user2Info.name);
+	store.setLoginInfo({ id: user2Info.id, name: user2Info.name });
 	store.addRooms([mockedRoom]);
 });
 describe('Leave conversation Action', () => {

--- a/src/chats/components/infoPanel/conversationInfo/GroupRoomPictureHandler.test.tsx
+++ b/src/chats/components/infoPanel/conversationInfo/GroupRoomPictureHandler.test.tsx
@@ -53,7 +53,7 @@ const testRoom2: RoomBe = createMockRoom({
 
 beforeEach(() => {
 	const store: RootStore = useStore.getState();
-	store.setLoginInfo(user1Info.id, user1Info.name);
+	store.setLoginInfo({ id: user1Info.id, name: user1Info.name });
 	store.setUserInfo([user1Info, user2Info]);
 	store.addRooms([testRoom, testRoom2]);
 });

--- a/src/chats/components/infoPanel/conversationInfo/OneToOneRoomPictureHandler.test.tsx
+++ b/src/chats/components/infoPanel/conversationInfo/OneToOneRoomPictureHandler.test.tsx
@@ -32,7 +32,7 @@ const testRoom: RoomBe = createMockRoom({
 
 beforeEach(() => {
 	const store: RootStore = useStore.getState();
-	store.setLoginInfo(user1Info.id, user1Info.name);
+	store.setLoginInfo({ id: user1Info.id, name: user1Info.name });
 	store.setUserInfo([user1Info, user2Info]);
 	store.addRooms([testRoom]);
 	store.setAttributes(createMockAttributesList({ carbonioWscShowUsersPresence: 'TRUE' }));

--- a/src/chats/components/infoPanel/conversationParticipantsAccordion/MemberComponentActions.test.tsx
+++ b/src/chats/components/infoPanel/conversationParticipantsAccordion/MemberComponentActions.test.tsx
@@ -112,7 +112,7 @@ vi.mock('../../../../hooks/useRouting');
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo(user1Info.id, user1Info.name);
+	store.setLoginInfo({ id: user1Info.id, name: user1Info.name });
 	store.setUserInfo([user1Info, user2Info, user3Info]);
 	store.addRooms([mockedOneToOne, mockedRoom, mockedRoom2]);
 	store.setAttributes(

--- a/src/chats/components/infoPanel/conversationParticipantsAccordion/MemberComponentInfo.test.tsx
+++ b/src/chats/components/infoPanel/conversationParticipantsAccordion/MemberComponentInfo.test.tsx
@@ -72,7 +72,7 @@ const mockedRoomOneOwner = createMockRoom({
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo(user1Be.id, user1Be.name);
+	store.setLoginInfo({ id: user1Be.id, name: user1Be.name });
 	store.addRooms([mockedRoomOneOwner, mockedRoom]);
 	store.setUserInfo([user1Be, user2Be, user3Be, user4Be]);
 });
@@ -145,7 +145,7 @@ describe('Participant component info', () => {
 	describe("User isn't an owner", () => {
 		test('The user is not an owner and sees his element inside list', () => {
 			const store = useStore.getState();
-			store.setLoginInfo('user2', 'User 2');
+			store.setLoginInfo({ id: 'user2', name: 'User 2' });
 			store.setAttributes(createMockAttributesList({ carbonioWscPrivateChatCreation: 'TRUE' }));
 			setup(<MemberComponentInfo member={members[1]} roomId={mockedRoom.id} />);
 
@@ -157,7 +157,7 @@ describe('Participant component info', () => {
 		});
 		test('the user is not an owner and sees an owner inside list', () => {
 			const store = useStore.getState();
-			store.setLoginInfo('user2', 'User 2');
+			store.setLoginInfo({ id: 'user2', name: 'User 2' });
 			store.setAttributes(createMockAttributesList({ carbonioWscPrivateChatCreation: 'TRUE' }));
 			setup(<MemberComponentInfo member={members[0]} roomId={mockedRoom.id} />);
 
@@ -172,7 +172,7 @@ describe('Participant component info', () => {
 		});
 		test('The user is not an owner and sees a normal user inside list', () => {
 			const store = useStore.getState();
-			store.setLoginInfo('user2', 'User 2');
+			store.setLoginInfo({ id: 'user2', name: 'User 2' });
 			store.setAttributes(createMockAttributesList({ carbonioWscPrivateChatCreation: 'TRUE' }));
 			setup(<MemberComponentInfo member={members[3]} roomId={mockedRoom.id} />);
 

--- a/src/chats/components/searchPanel/ConversationSearchPanel.test.tsx
+++ b/src/chats/components/searchPanel/ConversationSearchPanel.test.tsx
@@ -50,7 +50,7 @@ const oneToOneRoom: RoomBe = createMockRoom({
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo(loggedUser.id, loggedUser.name);
+	store.setLoginInfo({ id: loggedUser.id, name: loggedUser.name });
 	store.setUserInfo([loggedUser, user2]);
 	store.addRooms([groupRoom, oneToOneRoom]);
 });

--- a/src/chats/components/secondaryBar/SecondaryBarView.test.tsx
+++ b/src/chats/components/secondaryBar/SecondaryBarView.test.tsx
@@ -120,10 +120,10 @@ beforeEach(() => {
 	store.setLoginInfo({ id: user1Be.id, name: user1Be.name });
 	store.addRooms([mockedGroup1, mockedOneToOne1, mockedGroup2, mockedOneToOne2]);
 	store.setUserInfo([user1Be, user2Be, user3Be]);
-	store.newMessage(mkdTextMsgUser3Group1);
-	store.newMessage(mkdTextMsgUser1OneToOne);
-	store.newMessage(mkdTextMsgUser2OneToOne);
-	store.newMessage(mkdTextMsgUser3Group2);
+	store.setInboxMessages([mkdTextMsgUser3Group1]);
+	store.setInboxMessages([mkdTextMsgUser1OneToOne]);
+	store.setInboxMessages([mkdTextMsgUser2OneToOne]);
+	store.setInboxMessages([mkdTextMsgUser3Group2]);
 	store.setAttributes(createMockAttributesList({ carbonioWscPrivateChatCreation: 'TRUE' }));
 });
 describe('SecondaryBar tests', () => {

--- a/src/chats/components/secondaryBar/SecondaryBarView.test.tsx
+++ b/src/chats/components/secondaryBar/SecondaryBarView.test.tsx
@@ -117,7 +117,7 @@ vi.mock('../../../network/soap/SearchUsersByFeatureRequest');
 beforeEach(() => {
 	const store: RootStore = useStore.getState();
 	store.setChatsBeStatus(true);
-	store.setLoginInfo(user1Be.id, user1Be.name);
+	store.setLoginInfo({ id: user1Be.id, name: user1Be.name });
 	store.addRooms([mockedGroup1, mockedOneToOne1, mockedGroup2, mockedOneToOne2]);
 	store.setUserInfo([user1Be, user2Be, user3Be]);
 	store.newMessage(mkdTextMsgUser3Group1);

--- a/src/chats/components/secondaryBar/conversationList/CollapsedSidebarListItem.test.tsx
+++ b/src/chats/components/secondaryBar/conversationList/CollapsedSidebarListItem.test.tsx
@@ -42,7 +42,7 @@ const mockedOneToOne: RoomBe = createMockRoom({
 
 beforeEach(() => {
 	const store: RootStore = useStore.getState();
-	store.setLoginInfo(user1Be.id, user1Be.name);
+	store.setLoginInfo({ id: user1Be.id, name: user1Be.name });
 	store.setUserInfo([user1Be, user2Be]);
 	store.addRooms([mockedOneToOne, mockedGroup]);
 });

--- a/src/chats/components/secondaryBar/conversationList/ExpandedSidebarListItem.test.tsx
+++ b/src/chats/components/secondaryBar/conversationList/ExpandedSidebarListItem.test.tsx
@@ -149,7 +149,7 @@ const mockedAttachmentMessage = createMockTextMessage({
 
 beforeEach(() => {
 	const store: RootStore = useStore.getState();
-	store.setLoginInfo(user1Be.id, user1Be.name);
+	store.setLoginInfo({ id: user1Be.id, name: user1Be.name });
 	store.setUserInfo([user1Be, user2Be, user4Be]);
 	store.addRooms([mockedGroup, mockedOneToOne]);
 	store.setAttributes(createMockAttributesList({ carbonioWscShowMessageReads: 'TRUE' }));
@@ -249,7 +249,7 @@ describe('Expanded sidebar list item', () => {
 
 		test('Deleted image message', () => {
 			const store: RootStore = useStore.getState();
-			store.setLoginInfo(user2Be.id, user2Be.name);
+			store.setLoginInfo({ id: user2Be.id, name: user2Be.name });
 			store.newMessage(mockedConfigurationMessage);
 			setup(<ExpandedSidebarListItem roomId={mockedGroup.id} />);
 			expect(

--- a/src/chats/components/secondaryBar/conversationList/ExpandedSidebarListItem.test.tsx
+++ b/src/chats/components/secondaryBar/conversationList/ExpandedSidebarListItem.test.tsx
@@ -158,21 +158,9 @@ beforeEach(() => {
 describe('Expanded sidebar list item', () => {
 	describe('ACK status', () => {
 		describe('carbonioWscShowMessageReads = true', () => {
-			test('User is sending a message but it is in pending state', async () => {
-				const store: RootStore = useStore.getState();
-				store.setPlaceholderMessage({
-					roomId: mockedTextMessageUnread.roomId,
-					id: mockedTextMessageUnread.id,
-					text: mockedTextMessageUnread.text
-				});
-				setup(<ExpandedSidebarListItem roomId={mockedGroup.id} />);
-				expect(screen.getByTestId('icon: ClockOutline')).toBeVisible();
-				expect(screen.getByText(mockedTextMessageUnread.text)).toBeVisible();
-			});
-
 			test('User sent a message', async () => {
 				const store: RootStore = useStore.getState();
-				store.newMessage(mockedTextMessageUnread);
+				store.setInboxMessages([mockedTextMessageUnread]);
 				setup(<ExpandedSidebarListItem roomId={mockedGroup.id} />);
 				expect(screen.getByTestId('icon: Checkmark')).toBeVisible();
 				expect(screen.getByText(mockedTextMessageUnread.text)).toBeVisible();
@@ -180,7 +168,7 @@ describe('Expanded sidebar list item', () => {
 
 			test('User sent a message and someone read it', async () => {
 				const store: RootStore = useStore.getState();
-				store.newMessage(mockedTextMessageReadBySomeone);
+				store.setInboxMessages([mockedTextMessageReadBySomeone]);
 				setup(<ExpandedSidebarListItem roomId={mockedGroup.id} />);
 				expect(screen.getByTestId(iconDoneAll)).toBeVisible();
 				expect(screen.getByText(mockedTextMessageReadBySomeone.text)).toBeVisible();
@@ -188,7 +176,7 @@ describe('Expanded sidebar list item', () => {
 
 			test('User sent a message and everyone read it', async () => {
 				const store: RootStore = useStore.getState();
-				store.newMessage(mockedTextMessageRead);
+				store.setInboxMessages([mockedTextMessageRead]);
 				setup(<ExpandedSidebarListItem roomId={mockedGroup.id} />);
 				expect(screen.getByTestId(iconDoneAll)).toBeVisible();
 				expect(screen.getByText(mockedTextMessageRead.text)).toBeVisible();
@@ -196,23 +184,10 @@ describe('Expanded sidebar list item', () => {
 		});
 
 		describe('carbonioWscShowMessageReads = false', () => {
-			test('User is sending a message but it is in pending state', async () => {
-				const store: RootStore = useStore.getState();
-				store.setAttributes(createMockAttributesList({ carbonioWscShowMessageReads: 'FALSE' }));
-				store.setPlaceholderMessage({
-					roomId: mockedTextMessageUnread.roomId,
-					id: mockedTextMessageUnread.id,
-					text: mockedTextMessageUnread.text
-				});
-				setup(<ExpandedSidebarListItem roomId={mockedGroup.id} />);
-				expect(screen.getByTestId('icon: ClockOutline')).toBeVisible();
-				expect(screen.getByText(mockedTextMessageUnread.text)).toBeVisible();
-			});
-
 			test('User sent a message', async () => {
 				const store: RootStore = useStore.getState();
 				store.setAttributes(createMockAttributesList({ carbonioWscShowMessageReads: 'FALSE' }));
-				store.newMessage(mockedTextMessageUnread);
+				store.setInboxMessages([mockedTextMessageUnread]);
 				setup(<ExpandedSidebarListItem roomId={mockedGroup.id} />);
 				expect(screen.queryByTestId('icon: Checkmark')).not.toBeInTheDocument();
 				expect(screen.getByText(mockedTextMessageUnread.text)).toBeInTheDocument();
@@ -221,7 +196,7 @@ describe('Expanded sidebar list item', () => {
 			test('User sent a message and someone read it', async () => {
 				const store: RootStore = useStore.getState();
 				store.setAttributes(createMockAttributesList({ carbonioWscShowMessageReads: 'FALSE' }));
-				store.newMessage(mockedTextMessageReadBySomeone);
+				store.setInboxMessages([mockedTextMessageReadBySomeone]);
 				setup(<ExpandedSidebarListItem roomId={mockedGroup.id} />);
 				expect(screen.queryByTestId(iconDoneAll)).not.toBeInTheDocument();
 				expect(screen.getByText(mockedTextMessageReadBySomeone.text)).toBeVisible();
@@ -232,7 +207,7 @@ describe('Expanded sidebar list item', () => {
 	describe('Group List Item', () => {
 		test('A user of a group sent a message', async () => {
 			const store: RootStore = useStore.getState();
-			store.newMessage(mockedTextMessageSentBySomeoneElse);
+			store.setInboxMessages([mockedTextMessageSentBySomeoneElse]);
 			setup(<ExpandedSidebarListItem roomId={mockedGroup.id} />);
 			const message = `${user2Be.name}: ${mockedTextMessageSentBySomeoneElse.text}`;
 			expect(screen.getByText(message)).toBeVisible();
@@ -240,7 +215,7 @@ describe('Expanded sidebar list item', () => {
 
 		test('Added a new member message', () => {
 			const store: RootStore = useStore.getState();
-			store.newMessage(mockedAddMemberMessage);
+			store.setInboxMessages([mockedAddMemberMessage]);
 			setup(<ExpandedSidebarListItem roomId={mockedGroup.id} />);
 			expect(
 				screen.getByText(new RegExp(`${user4Be.name} has been added to ${mockedGroup.name}`, 'i'))
@@ -250,7 +225,7 @@ describe('Expanded sidebar list item', () => {
 		test('Deleted image message', () => {
 			const store: RootStore = useStore.getState();
 			store.setLoginInfo({ id: user2Be.id, name: user2Be.name });
-			store.newMessage(mockedConfigurationMessage);
+			store.setInboxMessages([mockedConfigurationMessage]);
 			setup(<ExpandedSidebarListItem roomId={mockedGroup.id} />);
 			expect(
 				screen.getByText(
@@ -263,14 +238,14 @@ describe('Expanded sidebar list item', () => {
 	describe('One to One List Item', () => {
 		test('Other user sent a message', async () => {
 			const store: RootStore = useStore.getState();
-			store.newMessage(mockedTextMessageSentByOther);
+			store.setInboxMessages([mockedTextMessageSentByOther]);
 			setup(<ExpandedSidebarListItem roomId={mockedOneToOne.id} />);
 			expect(screen.getByText(`${mockedTextMessageSentByOther.text}`)).toBeVisible();
 		});
 
 		test('when another user is typing, "is typing" message is rendered without an attachment icon', async () => {
 			const store: RootStore = useStore.getState();
-			store.newMessage(mockedAttachmentMessage);
+			store.setInboxMessages([mockedAttachmentMessage]);
 			store.setIsWriting(mockedOneToOne.id, user2Be.id, true);
 			setup(<ExpandedSidebarListItem roomId={mockedOneToOne.id} />);
 			expect(screen.queryByTestId('icon: FileTextOutline')).not.toBeInTheDocument();
@@ -282,7 +257,7 @@ describe('Expanded sidebar list item', () => {
 	describe('Icon and message', () => {
 		test('draft message situation', async () => {
 			const store: RootStore = useStore.getState();
-			store.newMessage(mockedTextMessageRead);
+			store.setInboxMessages([mockedTextMessageRead]);
 			const draftMessage = 'hi everyone!';
 			store.setDraftMessage(mockedGroup.id, draftMessage);
 			setup(<ExpandedSidebarListItem roomId={mockedGroup.id} />);
@@ -300,7 +275,7 @@ describe('Expanded sidebar list item', () => {
 
 		test('should not render the attachment icon if there is a draft content and the last message is an attachment', async () => {
 			const store: RootStore = useStore.getState();
-			store.newMessage(mockedAttachmentMessage);
+			store.setInboxMessages([mockedAttachmentMessage]);
 			store.setDraftMessage(mockedGroup.id, 'draft');
 			setup(<ExpandedSidebarListItem roomId={mockedGroup.id} />);
 			expect(screen.queryByTestId('icon: FileTextOutline')).not.toBeInTheDocument();
@@ -308,7 +283,7 @@ describe('Expanded sidebar list item', () => {
 
 		test('when another user is typing and there is a draft, "is typing" message is rendered without an draft icon', async () => {
 			const store: RootStore = useStore.getState();
-			store.newMessage(mockedTextMessageRead);
+			store.setInboxMessages([mockedTextMessageRead]);
 			const draftMessage = 'hi everyone!';
 			store.setDraftMessage(mockedGroup.id, draftMessage);
 			store.setIsWriting(mockedGroup.id, user2Be.id, true);
@@ -321,7 +296,7 @@ describe('Expanded sidebar list item', () => {
 
 		test('when another user stops typing, after 7 seconds the last message sent is rendered', async () => {
 			const store: RootStore = useStore.getState();
-			store.newMessage(mockedTextMessageSentByMeIntoGroup);
+			store.setInboxMessages([mockedTextMessageSentByMeIntoGroup]);
 			setup(<ExpandedSidebarListItem roomId={mockedGroup.id} />);
 			act(() => {
 				onComposingMessageStanza.call(

--- a/src/chats/components/secondaryBar/conversationList/ExpandedSidebarListItem.tsx
+++ b/src/chats/components/secondaryBar/conversationList/ExpandedSidebarListItem.tsx
@@ -12,14 +12,13 @@ import { useTranslation } from 'react-i18next';
 
 import { ConfigurationMessageLabel } from '../../../../hooks/useConfigurationMessageLabel';
 import { useIsWritingLabel } from '../../../../hooks/useIsWritingLabel';
-import useMessage from '../../../../hooks/useMessage';
 import useRouting from '../../../../hooks/useRouting';
 import {
 	getDraftMessage,
 	getLastNewReaction
 } from '../../../../store/selectors/ActiveConversationsSelectors';
 import {
-	getLastMessageIdSelector,
+	getLastMessageSelector,
 	getRoomUnreadSelector
 } from '../../../../store/selectors/ChatsRegistrySelectors';
 import {
@@ -33,7 +32,7 @@ import {
 } from '../../../../store/selectors/SessionSelectors';
 import { getUserName } from '../../../../store/selectors/UsersSelectors';
 import useStore from '../../../../store/Store';
-import { MarkerStatus, Message, MessageType } from '../../../../types/store/ChatsRegistryTypes';
+import { MarkerStatus, MessageType } from '../../../../types/store/ChatsRegistryTypes';
 import { RoomType } from '../../../../types/store/RoomTypes';
 import GroupAvatar from '../../GroupAvatar';
 import UserAvatar from '../../UserAvatar';
@@ -60,15 +59,12 @@ const ExpandedSidebarListItem: React.FC<ExpandedSidebarListItemProps> = ({ roomI
 	const { goToRoomPage } = useRouting();
 
 	const sessionId: string | undefined = useStore((store) => store.session.id);
-	const lastMessageId: string | undefined = useStore((state) =>
-		getLastMessageIdSelector(state, roomId)
-	);
-	const lastMessageOfRoom: Message | undefined = useMessage(roomId, lastMessageId ?? '');
 	const unreadMessagesCount = useStore((store) => getRoomUnreadSelector(store, roomId));
 	const lastNewReaction = useStore((store) => getLastNewReaction(store, roomId));
 	const roomType = useStore((state) => getRoomTypeSelector(state, roomId));
 	const roomName = useStore((state) => getRoomNameSelector(state, roomId));
 	const isConversationSelected = useStore((state) => getSelectedConversation(state, roomId));
+	const lastMessageOfRoom = useStore((state) => getLastMessageSelector(state, roomId));
 	const userNameOfLastMessageOfRoom = useStore((store) =>
 		lastMessageOfRoom && lastMessageOfRoom.type === MessageType.TEXT_MSG
 			? getUserName(store, lastMessageOfRoom.from)
@@ -154,7 +150,6 @@ const ExpandedSidebarListItem: React.FC<ExpandedSidebarListItemProps> = ({ roomI
 				case MessageType.CONFIGURATION_MSG:
 					return <ConfigurationMessageLabel message={lastMessageOfRoom} />;
 				default:
-					console.error('Message to replace: ', lastMessageOfRoom.type);
 					return '';
 			}
 		}

--- a/src/chats/components/secondaryBar/virtualRoomWidget/CreateVirtualRoomModal.test.tsx
+++ b/src/chats/components/secondaryBar/virtualRoomWidget/CreateVirtualRoomModal.test.tsx
@@ -43,7 +43,7 @@ vi.mock('../../../../network/soap/SearchUsersByFeatureRequest');
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo(sessionUser.id, sessionUser.name);
+	store.setLoginInfo({ id: sessionUser.id, name: sessionUser.name });
 	store.setUserInfo([user1, user2]);
 	store.setAttributes(createMockAttributesList());
 });

--- a/src/chats/components/secondaryBar/virtualRoomWidget/DeleteVirtualRoomModal.test.tsx
+++ b/src/chats/components/secondaryBar/virtualRoomWidget/DeleteVirtualRoomModal.test.tsx
@@ -40,7 +40,7 @@ describe('SelectVirtualRoomWidget', () => {
 		const spyOnDeleteRoomAndMeeting = vi.spyOn(api, 'deleteRoomAndMeeting');
 		act(() => {
 			const store = useStore.getState();
-			store.setLoginInfo(sessionUser.id, sessionUser.name);
+			store.setLoginInfo({ id: sessionUser.id, name: sessionUser.name });
 			store.setAttributes(createMockAttributesList());
 			store.addRooms([temporaryRoomMod]);
 			store.addMeetings([scheduledMeetingMod]);

--- a/src/chats/components/secondaryBar/virtualRoomWidget/VirtualRoomsButton.test.tsx
+++ b/src/chats/components/secondaryBar/virtualRoomWidget/VirtualRoomsButton.test.tsx
@@ -29,7 +29,7 @@ vi.mock('../../../../network/soap/Requests/SearchUsersByFeatureRequest');
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo(sessionUser.id, sessionUser.name);
+	store.setLoginInfo({ id: sessionUser.id, name: sessionUser.name });
 	store.setUserInfo([user1]);
 	store.setAttributes(createMockAttributesList({ carbonioWscVideoCallEnabled: 'TRUE' }));
 	store.addMeetings([virtualRoom]);

--- a/src/chats/components/secondaryBar/virtualRoomWidget/virtualRoomCard/VirtualRoomCard.test.tsx
+++ b/src/chats/components/secondaryBar/virtualRoomWidget/virtualRoomCard/VirtualRoomCard.test.tsx
@@ -58,7 +58,7 @@ const memberMeeting = createMockMeeting({
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo(sessionUser.id, sessionUser.name);
+	store.setLoginInfo({ id: sessionUser.id, name: sessionUser.name });
 	store.setUserInfo([sessionUser, userOne]);
 	store.addRooms([ownerRoom, ownersRoom, memberRoom]);
 	store.addMeetings([ownerMeeting, ownersMeeting, memberMeeting]);

--- a/src/chats/components/userPopoverList/UserPopoverList.test.tsx
+++ b/src/chats/components/userPopoverList/UserPopoverList.test.tsx
@@ -29,7 +29,7 @@ const RefComponent = (props: Omit<UserPopoverListProps, 'anchorEl'>): ReactEleme
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo(sessionUser.id, sessionUser.email);
+	store.setLoginInfo({ id: sessionUser.id, name: sessionUser.email });
 	store.setUserInfo([user1, user2]);
 });
 

--- a/src/chats/views/DefaultUserSidebarView.test.tsx
+++ b/src/chats/views/DefaultUserSidebarView.test.tsx
@@ -19,7 +19,7 @@ describe('DefaultUserSidebarView', () => {
 	test('should render virtual button when empty', () => {
 		act(() => {
 			useStore.getState().setUserInfo([user1]);
-			useStore.getState().setLoginInfo('user1Id', 'user 1');
+			useStore.getState().setLoginInfo({ id: 'user1Id', name: 'user 1' });
 			useStore
 				.getState()
 				.setAttributes(createMockAttributesList({ carbonioWscVideoCallEnabled: 'TRUE' }));

--- a/src/hooks/useConfigurationMessageLabel.test.tsx
+++ b/src/hooks/useConfigurationMessageLabel.test.tsx
@@ -45,7 +45,7 @@ const oneToOneRoom = createMockRoom({
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo(loggedUser.id, loggedUser.name);
+	store.setLoginInfo({ id: loggedUser.id, name: loggedUser.name });
 	store.setUserInfo([loggedUser, user1, user2]);
 	store.addRooms([groupRoom, oneToOneRoom]);
 });

--- a/src/hooks/useFilterRoomsOnInput.test.tsx
+++ b/src/hooks/useFilterRoomsOnInput.test.tsx
@@ -32,7 +32,7 @@ const single2 = createMockRoom({
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo('sessionId', 'User Name');
+	store.setLoginInfo({ id: 'sessionId' });
 	store.setUserInfo([user1, user2, user3]);
 });
 

--- a/src/hooks/useGeneralMeetingControls.test.tsx
+++ b/src/hooks/useGeneralMeetingControls.test.tsx
@@ -20,7 +20,7 @@ vi.mock('../hooks/useRouting');
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo('userId', 'User');
+	store.setLoginInfo({ id: 'userId', name: 'User' });
 	store.setChatsBeStatus(true);
 	store.setWebsocketStatus(true);
 	store.meetingConnection(meeting.id);

--- a/src/hooks/usePinMessage.test.tsx
+++ b/src/hooks/usePinMessage.test.tsx
@@ -23,7 +23,7 @@ const user2 = createMockUser({ id: 'user2', name: 'user2' });
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo(user1.id, 'user1');
+	store.setLoginInfo({ id: user1.id, name: 'user1' });
 	store.setUserInfo([user1, user2]);
 });
 

--- a/src/hooks/useTilesOrder.test.tsx
+++ b/src/hooks/useTilesOrder.test.tsx
@@ -24,7 +24,7 @@ const participant5 = createMockParticipants({ userId: '5', joinedAt: '2023-09-18
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo('0', 'User');
+	store.setLoginInfo({ id: '0' });
 	store.addRooms([room]);
 	store.addMeetings([meeting]);
 	store.meetingConnection(meeting.id);

--- a/src/integrations/virtualRoomIntegration/SelectVirtualRoomWidget.test.tsx
+++ b/src/integrations/virtualRoomIntegration/SelectVirtualRoomWidget.test.tsx
@@ -38,7 +38,7 @@ describe('SelectVirtualRoomWidget', () => {
 	test('Should render properly - user has virtual rooms', async () => {
 		act(() => {
 			const store = useStore.getState();
-			store.setLoginInfo(sessionUser.id, sessionUser.name);
+			store.setLoginInfo({ id: sessionUser.id, name: sessionUser.name });
 			store.setAttributes(createMockAttributesList());
 			store.addRooms([temporaryRoomMod]);
 			store.addMeetings([scheduledMeetingMod]);
@@ -64,7 +64,7 @@ describe('SelectVirtualRoomWidget', () => {
 
 	test('Should render properly - user has not virtual rooms and defaultValue is not undefined', async () => {
 		const store = useStore.getState();
-		store.setLoginInfo(sessionUser.id, sessionUser.name);
+		store.setLoginInfo({ id: sessionUser.id, name: sessionUser.name });
 		store.setAttributes(createMockAttributesList());
 		await act(async () => {
 			setup(

--- a/src/meetings/components/MeetingNotificationsHandler.test.tsx
+++ b/src/meetings/components/MeetingNotificationsHandler.test.tsx
@@ -29,6 +29,7 @@ const meeting = createMockMeeting({ id: 'meetingId', roomId: room.id });
 
 const room1 = createMockRoom({ id: 'roomId1', type: RoomType.ONE_TO_ONE });
 const meeting1 = createMockMeeting({ id: 'meetingId1', roomId: room1.id });
+
 const addIncomingMeetingNotification = (room: RoomBe, meeting: MeetingBe): void => {
 	const event: MeetingStartedEvent = {
 		sentDate: '2412412421',
@@ -37,14 +38,16 @@ const addIncomingMeetingNotification = (room: RoomBe, meeting: MeetingBe): void 
 		starterUser: room.id,
 		startedAt: '2024-04-04T15:42:22.932426Z'
 	};
-	const store = useStore.getState();
 	act(() => {
-		store.addRooms([room]);
-		store.addMeetings([meeting]);
 		sendCustomEvent({ name: EventName.INCOMING_MEETING, data: event });
 	});
 };
 
+beforeEach(() => {
+	const store = useStore.getState();
+	store.addRooms([room, room1]);
+	store.addMeetings([meeting, meeting1]);
+});
 describe('MeetingNotificationsHandler', () => {
 	test('Nothing is rendered when there are no notifications', () => {
 		setup(<MeetingNotificationsHandler />);

--- a/src/meetings/components/RecordingInfo.test.tsx
+++ b/src/meetings/components/RecordingInfo.test.tsx
@@ -38,7 +38,7 @@ const meeting: MeetingBe = createMockMeeting({
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo(user1.id, 'user1');
+	store.setLoginInfo({ id: user1.id, name: 'user1' });
 	store.setUserInfo([user1, user2]);
 	store.addRooms([room]);
 	store.addMeetings([meeting]);

--- a/src/meetings/components/bubblesWrapper/BubblesWrapper.test.tsx
+++ b/src/meetings/components/bubblesWrapper/BubblesWrapper.test.tsx
@@ -66,7 +66,7 @@ const message = createMockTextMessage({
 
 const storeBasicActiveMeetingSetup = (): { user: UserEvent; store: RootStore } => {
 	const store: RootStore = useStore.getState();
-	store.setLoginInfo(user1.id, user1.name);
+	store.setLoginInfo({ id: user1.id, name: user1.name });
 	store.setUserInfo([user1, user2, user3]);
 	store.addRooms([room]);
 	store.addMeetings([meeting]);

--- a/src/meetings/components/headerMeetingButton/ActiveMeetingParticipantsDropdown.test.tsx
+++ b/src/meetings/components/headerMeetingButton/ActiveMeetingParticipantsDropdown.test.tsx
@@ -49,7 +49,7 @@ const meeting: MeetingBe = createMockMeeting({
 
 beforeEach(() => {
 	const store: RootStore = useStore.getState();
-	store.setLoginInfo(user1.id, user1.name);
+	store.setLoginInfo({ id: user1.id, name: user1.name });
 	store.setUserInfo([user1, user2, user3]);
 	store.addRooms([room]);
 	store.addMeetings([meeting]);

--- a/src/meetings/components/headerMeetingButton/ConversationHeaderMeetingButton.test.tsx
+++ b/src/meetings/components/headerMeetingButton/ConversationHeaderMeetingButton.test.tsx
@@ -73,7 +73,7 @@ vi.mock('../../../hooks/useRouting');
 beforeEach(() => {
 	window.open = vi.fn(() => null);
 	const store = useStore.getState();
-	store.setLoginInfo(user1.id, user1.name);
+	store.setLoginInfo({ id: user1.id, name: user1.name });
 	store.setUserInfo([user1, user2, user3]);
 	store.addRooms([oneToOneRoom, groupRoom]);
 	store.setAttributes(

--- a/src/meetings/components/headerMeetingButton/ParticipantElement.test.tsx
+++ b/src/meetings/components/headerMeetingButton/ParticipantElement.test.tsx
@@ -22,7 +22,7 @@ const activeMeeting = createMockMeeting({});
 beforeEach(() => {
 	const store = useStore.getState();
 	store.addMeetings([activeMeeting]);
-	store.setLoginInfo(loggedUser.id, loggedUser.name, loggedUser.type);
+	store.setLoginInfo({ id: loggedUser.id, name: loggedUser.name, userType: loggedUser.type });
 });
 
 describe('ParticipantElement', () => {

--- a/src/meetings/components/meetingAccessPoint/MeetingAccessPageMediaSection.test.tsx
+++ b/src/meetings/components/meetingAccessPoint/MeetingAccessPageMediaSection.test.tsx
@@ -48,7 +48,7 @@ const groupMeeting: MeetingBe = createMockMeeting({
 beforeEach(() => {
 	const store = useStore.getState();
 	store.setUserInfo([user1, user2]);
-	store.setLoginInfo(user1.id, user1.name);
+	store.setLoginInfo({ id: user1.id, name: user1.name });
 	store.addRooms([groupRoom]);
 	store.addMeetings([groupMeeting]);
 	store.setChatsBeStatus(true);

--- a/src/meetings/components/meetingAccessPoint/externalAccess/useExternalAccess.tsx
+++ b/src/meetings/components/meetingAccessPoint/externalAccess/useExternalAccess.tsx
@@ -61,7 +61,7 @@ const useExternalAccess = (): {
 				.then((res) => {
 					document.cookie = `ZM_AUTH_TOKEN=${res.zmToken}; path=/`;
 					document.cookie = `ZX_AUTH_TOKEN=${res.zxToken}; path=/`;
-					setLoginInfo(res.id, guestName, guestName, UserType.GUEST);
+					setLoginInfo({ id: res.id, name: guestName, userType: UserType.GUEST });
 
 					setChatsBeStatus(true);
 					xmppClient.connect(res.zmToken);

--- a/src/meetings/components/meetingActionsBar/CameraButtonPermissionDenied.test.tsx
+++ b/src/meetings/components/meetingActionsBar/CameraButtonPermissionDenied.test.tsx
@@ -66,7 +66,7 @@ beforeEach(() => {
 	const store = useStore.getState();
 	store.setWebsocketStatus(true);
 	store.setUserInfo([user1, user2]);
-	store.setLoginInfo(user1.id, user1.name);
+	store.setLoginInfo({ id: user1.id, name: user1.name });
 	store.addRooms([room]);
 	store.addMeetings([meeting]);
 	store.meetingConnection(meeting.id);

--- a/src/meetings/components/meetingActionsBar/MeetingActionsBar.test.tsx
+++ b/src/meetings/components/meetingActionsBar/MeetingActionsBar.test.tsx
@@ -51,7 +51,7 @@ const streamRef = React.createRef<HTMLDivElement>();
 
 beforeEach(() => {
 	const store: RootStore = useStore.getState();
-	store.setLoginInfo(user1.id, user1.name);
+	store.setLoginInfo({ id: user1.id, name: user1.name });
 	store.setUserInfo([user1, user2, user3]);
 	store.addRooms([room]);
 	store.addMeetings([meeting]);

--- a/src/meetings/components/meetingActionsBar/MoreActionsButton.test.tsx
+++ b/src/meetings/components/meetingActionsBar/MoreActionsButton.test.tsx
@@ -72,7 +72,7 @@ const meetingWithOnePerson: MeetingBe = createMockMeeting({
 const storeSetupGroupMeeting = (): { user: UserEvent; store: RootStore } => {
 	const store = useStore.getState();
 	store.setUserInfo([user1, user2, user3]);
-	store.setLoginInfo(user1.id, user1.name);
+	store.setLoginInfo({ id: user1.id, name: user1.name });
 	store.addRooms([room]);
 	store.addMeetings([meeting]);
 	store.meetingConnection(meeting.id);
@@ -88,7 +88,7 @@ const storeSetupGroupMeetingWithOnePerson = (): { user: UserEvent } => {
 	const { result } = renderHook(() => useStore());
 	act(() => {
 		result.current.setUserInfo([user1]);
-		result.current.setLoginInfo(user1.id, user1.name);
+		result.current.setLoginInfo({ id: user1.id, name: user1.name });
 		result.current.addRooms([room]);
 		result.current.addMeetings([meetingWithOnePerson]);
 		result.current.meetingConnection(meetingWithOnePerson.id);
@@ -110,7 +110,7 @@ const customPiPContextValue = {
 const storeSetupGroupMeetingPip = (): { user: UserEvent; store: RootStore } => {
 	const store = useStore.getState();
 	store.setUserInfo([user1, user2, user3]);
-	store.setLoginInfo(user1.id, user1.name);
+	store.setLoginInfo({ id: user1.id, name: user1.name });
 	store.addRooms([room]);
 	store.addMeetings([meeting]);
 	store.meetingConnection(meeting.id);

--- a/src/meetings/components/meetingActionsBar/RaiseHandButton.test.tsx
+++ b/src/meetings/components/meetingActionsBar/RaiseHandButton.test.tsx
@@ -58,7 +58,7 @@ const meeting: MeetingBe = createMockMeeting({
 const storeSetupGroupMeeting = (): { user: UserEvent; store: RootStore } => {
 	const store = useStore.getState();
 	store.setUserInfo([user1, user2, user3]);
-	store.setLoginInfo(user1.id, user1.name);
+	store.setLoginInfo({ id: user1.id, name: user1.name });
 	store.addRooms([room]);
 	store.addMeetings([meeting]);
 	store.meetingConnection(meeting.id);

--- a/src/meetings/components/meetingActionsBar/ScreenShareButton.test.tsx
+++ b/src/meetings/components/meetingActionsBar/ScreenShareButton.test.tsx
@@ -39,7 +39,7 @@ describe('ScreenShare button', () => {
 		useParams.mockReturnValue({ meetingId: meeting.id });
 		const store = useStore.getState();
 		store.setWebsocketStatus(true);
-		store.setLoginInfo('userId', 'User', 'User');
+		store.setLoginInfo({ id: 'userId', name: 'User' });
 		store.addMeetings([
 			createMockMeeting({
 				id: meeting.id,
@@ -54,7 +54,7 @@ describe('ScreenShare button', () => {
 	test('ScreenSharingOn icon when screenshare is enabled', async () => {
 		const store = useStore.getState();
 		store.setWebsocketStatus(true);
-		store.setLoginInfo('userId', 'User', 'User');
+		store.setLoginInfo({ id: 'userId', name: 'User' });
 		store.addMeetings([
 			createMockMeeting({
 				id: meeting.id,

--- a/src/meetings/components/mobile/MobileActionBar.test.tsx
+++ b/src/meetings/components/mobile/MobileActionBar.test.tsx
@@ -73,7 +73,7 @@ describe('MobileActionBar test', () => {
 	test('Toggle audio stream', async () => {
 		const spyOnUpdateAudioStreamStatus = vi.spyOn(api, 'updateAudioStreamStatus');
 		const store = useStore.getState();
-		store.setLoginInfo('userId', 'User');
+		store.setLoginInfo({ id: 'userId', name: 'User' });
 		store.addMeetings([mockMeeting]);
 		store.addParticipant(mockMeeting.id, {
 			userId: 'userId',

--- a/src/meetings/components/pictureInPicture/PictureInPictureView.test.tsx
+++ b/src/meetings/components/pictureInPicture/PictureInPictureView.test.tsx
@@ -58,7 +58,7 @@ const meeting: MeetingBe = createMockMeeting({
 const storeSetupGroupMeetingPip = (): { user: UserEvent; store: RootStore } => {
 	const store = useStore.getState();
 	store.setUserInfo([user1, user2, user3]);
-	store.setLoginInfo(user1.id, user1.name);
+	store.setLoginInfo({ id: user1.id, name: user1.name });
 	store.addRooms([room]);
 	store.addMeetings([meeting]);
 	store.meetingConnection(meeting.id);

--- a/src/meetings/components/sidebar/MeetingConversationAccordion/MeetingConversationAccordion.test.tsx
+++ b/src/meetings/components/sidebar/MeetingConversationAccordion/MeetingConversationAccordion.test.tsx
@@ -71,7 +71,7 @@ const setupBasicGroup = (): { user: UserEvent; store: RootStore } => {
 	const { result } = renderHook(() => useStore());
 	act(() => {
 		result.current.setAttributes(createMockAttributesList({ carbonioWscVideoCallEnabled: 'TRUE' }));
-		result.current.setLoginInfo(mockUser1.id, mockUser1.name);
+		result.current.setLoginInfo({ id: mockUser1.id });
 		result.current.setUserInfo([mockUser2]);
 		result.current.addRooms([groupRoom]);
 		result.current.addMeetings([groupMeeting]);
@@ -191,7 +191,7 @@ const setupTemporaryRoom = (
 	const { result } = renderHook(() => useStore());
 	act(() => {
 		result.current.setAttributes(createMockAttributesList({ carbonioWscVideoCallEnabled: 'TRUE' }));
-		result.current.setLoginInfo(mockUser1.id, mockUser1.name);
+		result.current.setLoginInfo({ id: mockUser1.id });
 		result.current.setUserInfo([mockUser2]);
 		result.current.setApiVersion('1.6.7');
 		result.current.addRooms([temporaryRoom]);

--- a/src/meetings/components/sidebar/MeetingSidebar.test.tsx
+++ b/src/meetings/components/sidebar/MeetingSidebar.test.tsx
@@ -94,7 +94,7 @@ const scheduledMeeting: MeetingBe = createMockMeeting({
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo(sessionUser.id, sessionUser.name);
+	store.setLoginInfo({ id: sessionUser.id, name: sessionUser.name });
 	store.setAttributes(createMockAttributesList({ carbonioWscRecordingEnabled: 'TRUE' }));
 	store.addRooms([oneToOneRoom, groupRoom, temporaryRoom, temporaryRoomMod]);
 	store.addMeetings([oneToOneMeeting, groupMeeting, scheduledMeeting, scheduledMeetingMod]);

--- a/src/meetings/components/sidebar/ParticipantsAccordion/MeetingParticipantsAccordion.test.tsx
+++ b/src/meetings/components/sidebar/ParticipantsAccordion/MeetingParticipantsAccordion.test.tsx
@@ -53,7 +53,7 @@ const storeSetupGroupMeetingModerator = (): { user: UserEvent; store: RootStore 
 		members: [member1, member2, member3]
 	});
 	store.setUserInfo([user1, user2, user3]);
-	store.setLoginInfo(user1.id, user1.name);
+	store.setLoginInfo({ id: user1.id, name: user1.name });
 	store.addRooms([room]);
 	const meeting: MeetingBe = createMockMeeting({
 		roomId: room.id,
@@ -79,7 +79,7 @@ const storeSetupParticipantModerator = (): {
 		members: [member1, member2]
 	});
 	store.setUserInfo([user1, user2]);
-	store.setLoginInfo(user1.id, user1.name);
+	store.setLoginInfo({ id: user1.id, name: user1.name });
 	store.addRooms([room]);
 
 	const meeting: MeetingBe = createMockMeeting({

--- a/src/meetings/components/sidebar/raiseHandAccordion/RaiseHandAccordion.test.tsx
+++ b/src/meetings/components/sidebar/raiseHandAccordion/RaiseHandAccordion.test.tsx
@@ -43,7 +43,7 @@ const meeting: MeetingBe = createMockMeeting({
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo(user1.id, 'user1');
+	store.setLoginInfo({ id: user1.id, name: 'user1' });
 	store.setUserInfo([user1, user2]);
 	store.addRooms([room]);
 	store.addMeetings([meeting]);
@@ -111,7 +111,7 @@ describe('Snackbar notifications', () => {
 	test('shows snackbar when moderator lowers your hand', () => {
 		const store = useStore.getState();
 		act(() => {
-			store.setLoginInfo(user2.id, 'user2');
+			store.setLoginInfo({ id: user2.id, name: 'user2' });
 			store.setUserWithHandRaised(user2.id, true);
 		});
 		setup(<RaiseHandAccordion meetingId={meeting.id} />);

--- a/src/meetings/components/sidebar/recordingAccordion/RecordingAccordion.test.tsx
+++ b/src/meetings/components/sidebar/recordingAccordion/RecordingAccordion.test.tsx
@@ -40,7 +40,7 @@ const iconDown = 'icon: ChevronDown';
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo(user1.id, 'user1');
+	store.setLoginInfo({ id: user1.id, name: 'user1' });
 	store.addRooms([room]);
 	store.addMeetings([meeting]);
 	store.meetingConnection(meeting.id);

--- a/src/meetings/components/sidebar/recordingAccordion/StopRecordingModal.test.tsx
+++ b/src/meetings/components/sidebar/recordingAccordion/StopRecordingModal.test.tsx
@@ -36,7 +36,7 @@ const meeting: MeetingBe = createMockMeeting({
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo(user1.id, 'user1');
+	store.setLoginInfo({ id: user1.id, name: 'user1' });
 	store.addRooms([room]);
 	store.addMeetings([meeting]);
 	store.meetingConnection(meeting.id);

--- a/src/meetings/components/sidebar/waitingListAccordion/WaitingListAccordion.test.tsx
+++ b/src/meetings/components/sidebar/waitingListAccordion/WaitingListAccordion.test.tsx
@@ -37,7 +37,7 @@ const meeting: MeetingBe = createMockMeeting({
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo(user1.id, 'user1');
+	store.setLoginInfo({ id: user1.id, name: 'user1' });
 	store.addRooms([room]);
 	store.addMeetings([meeting]);
 	store.meetingConnection(meeting.id);

--- a/src/meetings/components/tile/Tile.test.tsx
+++ b/src/meetings/components/tile/Tile.test.tsx
@@ -121,7 +121,7 @@ const storeSetupTileAudioOnAndVideoOff = (): { user: UserEvent; store: RootStore
 beforeEach(() => {
 	const store: RootStore = useStore.getState();
 	store.setUserInfo([user1, user2, user3]);
-	store.setLoginInfo(user1.id, user1.name);
+	store.setLoginInfo({ id: user1.id, name: user1.name });
 	store.addRooms([room]);
 	store.addMeetings([meeting]);
 });

--- a/src/meetings/components/whoIsSpeaking/WhoIsSpeaking.test.tsx
+++ b/src/meetings/components/whoIsSpeaking/WhoIsSpeaking.test.tsx
@@ -57,7 +57,7 @@ const centralTileScreen: TileData = {
 beforeEach(() => {
 	const store: RootStore = useStore.getState();
 	store.setUserInfo([user1, user2, user3]);
-	store.setLoginInfo(user1.id, user1.name);
+	store.setLoginInfo({ id: user1.id, name: user1.name });
 	store.addRooms([room]);
 	store.addMeetings([meeting]);
 	store.meetingConnection(meeting.id);

--- a/src/meetings/views/AccessPage.test.tsx
+++ b/src/meetings/views/AccessPage.test.tsx
@@ -71,7 +71,7 @@ const setupGroupForAccessPage = (): { user: UserEvent; store: RootStore } => {
 	const { result } = renderHook(() => useStore());
 	act(() => {
 		result.current.setUserInfo([user1, user2, user3]);
-		result.current.setLoginInfo(user3.id, user3.name);
+		result.current.setLoginInfo({ id: user3.id, name: user3.name });
 		result.current.addRooms([groupRoom]);
 		result.current.addMeetings([groupMeeting]);
 		result.current.setChatsBeStatus(true);
@@ -88,7 +88,7 @@ const setupAccessPage = (): { user: UserEvent; store: RootStore } => {
 	const { result } = renderHook(() => useStore());
 	act(() => {
 		result.current.setUserInfo([user2, user3]);
-		result.current.setLoginInfo(user2.id, user2.name);
+		result.current.setLoginInfo({ id: user2.id, name: user2.name });
 		result.current.addRooms([groupForWaitingRoom]);
 		result.current.addMeetings([meetingForWaitingRoom]);
 		result.current.setChatsBeStatus(true);

--- a/src/meetings/views/InfoPage.test.tsx
+++ b/src/meetings/views/InfoPage.test.tsx
@@ -85,7 +85,7 @@ describe('Info page', () => {
 		document.cookie = `ZX_AUTH_TOKEN=123456789; path=/`;
 		const guestUser = createMockUser({ type: UserType.GUEST });
 		const store = useStore.getState();
-		store.setLoginInfo(guestUser.id, guestUser.name, guestUser.name, guestUser.type);
+		store.setLoginInfo({ id: guestUser.id, userType: guestUser.type });
 		routerContextSetup(<InfoPage />, { infoType: type as PAGE_INFO_TYPE });
 
 		expect(document.cookie).toBe('');

--- a/src/meetings/views/MeetingSkeleton.test.tsx
+++ b/src/meetings/views/MeetingSkeleton.test.tsx
@@ -65,7 +65,7 @@ const meeting: MeetingBe = createMockMeeting({
 const storeSetupGroupMeetingSkeleton = (): { user: UserEvent; store: RootStore } => {
 	const store = useStore.getState();
 	store.setUserInfo([user1, user2, user3]);
-	store.setLoginInfo(user1.id, user1.name);
+	store.setLoginInfo({ id: user1.id, name: user1.name });
 	store.addRooms([room]);
 	store.addMeetings([meeting]);
 	store.meetingConnection(meeting.id, { enabled: false }, { enabled: true, deviceId: 'videoId' });

--- a/src/network/apis/MeetingsApi.test.ts
+++ b/src/network/apis/MeetingsApi.test.ts
@@ -73,7 +73,7 @@ vi.mock('../../utils/FetchUtils');
 beforeEach(() => {
 	const store: RootStore = useStore.getState();
 	store.setApiVersion('1.6.4');
-	store.setLoginInfo(userId, 'User');
+	store.setLoginInfo({ id: userId, name: 'User' });
 	store.setQueueId('queueId');
 	store.addRooms([roomMock]);
 });
@@ -259,7 +259,7 @@ describe('Meetings API', () => {
 	test('leaveMeeting for external user is called correctly', async () => {
 		document.cookie = `ZM_AUTH_TOKEN=123456789; path=/`;
 		document.cookie = `ZX_AUTH_TOKEN=123456789; path=/`;
-		useStore.getState().setLoginInfo(guestUser.id, guestUser.name, guestUser.name, guestUser.type);
+		useStore.getState().setLoginInfo({ id: guestUser.id, userType: guestUser.type });
 		await leaveMeeting(meetingMock.id);
 
 		expect(mockFetchAPI).toHaveBeenCalledWith(`meetings/${meetingMock.id}/leave`, RequestType.POST);
@@ -296,7 +296,7 @@ describe('Meetings API', () => {
 	test('leaveMeeting for external user is rejected', async () => {
 		document.cookie = `ZM_AUTH_TOKEN=123456789; path=/`;
 		document.cookie = `ZX_AUTH_TOKEN=123456789; path=/`;
-		useStore.getState().setLoginInfo(guestUser.id, guestUser.name, guestUser.name, guestUser.type);
+		useStore.getState().setLoginInfo({ id: guestUser.id, userType: guestUser.type });
 
 		await leaveMeeting(meetingMock.id);
 
@@ -431,7 +431,12 @@ describe('Meetings API', () => {
 
 	test('leaveWaitingRoom is called correctly for guest user', async () => {
 		document.cookie = `ZM_AUTH_TOKEN=123456789`;
-		useStore.getState().setLoginInfo(userId, guestUser.email, guestUser.name, guestUser.type);
+		useStore.getState().setLoginInfo({
+			id: userId,
+			name: guestUser.email,
+			displayName: guestUser.name,
+			userType: guestUser.type
+		});
 		useStore.getState().setQueueId('queueId');
 		await leaveWaitingRoom(meetingMock.id);
 

--- a/src/network/soap/SearchUsersByFeatureRequest.test.ts
+++ b/src/network/soap/SearchUsersByFeatureRequest.test.ts
@@ -69,7 +69,7 @@ describe('SearchUsersByFeatureRequest', () => {
 	});
 
 	test('Contact info of the current user will be removed', async () => {
-		useStore.getState().setLoginInfo(contact1Info.id, contact1Info.email);
+		useStore.getState().setLoginInfo({ id: contact1Info.id });
 		mockSoapFetchV2.mockReturnValueOnce({
 			SearchUsersByFeatureResponse: {
 				account: [contact1Match, contact2Match, contact3Match],

--- a/src/network/webRTC/SubscriptionsManager.test.ts
+++ b/src/network/webRTC/SubscriptionsManager.test.ts
@@ -89,7 +89,7 @@ vi.mock('../../utils/FetchUtils');
 beforeEach(() => {
 	act(() => {
 		const store = useStore.getState();
-		store.setLoginInfo(user1Info.id, user1Info.email, user1Info.name);
+		store.setLoginInfo({ id: user1Info.id, name: user1Info.email, displayName: user1Info.name });
 		store.addRooms([groupRoom]);
 		store.addMeetings([groupMeeting]);
 		store.meetingConnection(groupMeeting.id);

--- a/src/network/websocket/eventHandlersUtilities.test.ts
+++ b/src/network/websocket/eventHandlersUtilities.test.ts
@@ -83,12 +83,12 @@ describe('eventHandlersUtilities tests', () => {
 
 	describe('isMyId tests', () => {
 		test('isMyId returns true if the id is the same as the session userId', () => {
-			useStore.getState().setLoginInfo('userId', 'User');
+			useStore.getState().setLoginInfo({ id: 'userId', name: 'User' });
 			expect(isMyId('userId')).toBe(true);
 		});
 
 		test('isMyId returns false if the id is different from the session userId', () => {
-			useStore.getState().setLoginInfo('userId', 'User');
+			useStore.getState().setLoginInfo({ id: 'userId', name: 'User' });
 			expect(isMyId('otherId')).toBe(false);
 		});
 	});

--- a/src/network/websocket/wsConversationEventsHandler.test.ts
+++ b/src/network/websocket/wsConversationEventsHandler.test.ts
@@ -35,7 +35,7 @@ const room: RoomBe = createMockRoom({
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo(sessionUser.id, sessionUser.name);
+	store.setLoginInfo({ id: sessionUser.id, name: sessionUser.name });
 	store.addRooms([room]);
 });
 

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingAudioAnsweredEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingAudioAnsweredEventHandler.test.ts
@@ -25,7 +25,7 @@ const event: MeetingAudioAnsweredEvent = {
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo('myUserId', 'User');
+	store.setLoginInfo({ id: 'myUserId', name: 'User' });
 	store.addRooms([room]);
 	store.addMeetings([meeting]);
 });

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingAudioStreamChangedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingAudioStreamChangedEventHandler.test.ts
@@ -30,7 +30,7 @@ const event: MeetingAudioStreamChangedEvent = {
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo('sessionUserId', 'User');
+	store.setLoginInfo({ id: 'sessionUserId' });
 	store.addRooms([room]);
 	store.addMeetings([meeting]);
 	store.addParticipant(meeting.id, createMockParticipants({ userId: 'sessionUserId' }));

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingJoinedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingJoinedEventHandler.test.ts
@@ -58,7 +58,7 @@ const event2: MeetingJoinedEvent = {
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo('sessionUserId', 'User');
+	store.setLoginInfo({ id: 'sessionUserId' });
 	store.addRooms([room, room2, groupRoom]);
 	store.addMeetings([meeting, groupMeeting, meetingWith10Participants]);
 });

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingLeftEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingLeftEventHandler.test.ts
@@ -48,7 +48,7 @@ const event: MeetingLeftEvent = {
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo('myUserId', 'User');
+	store.setLoginInfo({ id: 'myUserId', name: 'User' });
 	store.addRooms([room, room2]);
 	store.addMeetings([meeting, meetingWith12Participants]);
 	store.meetingConnection(meeting.id);

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingMediaStreamChangedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingMediaStreamChangedEventHandler.test.ts
@@ -32,7 +32,7 @@ const event: MeetingMediaStreamChangedEvent = {
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo('myUserId', 'User');
+	store.setLoginInfo({ id: 'myUserId', name: 'User' });
 	store.addRooms([room]);
 	store.addMeetings([meeting]);
 	store.meetingConnection(meeting.id);

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingParticipantClashedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingParticipantClashedEventHandler.test.ts
@@ -27,7 +27,7 @@ const event: MeetingParticipantClashedEvent = {
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo('myUserId', 'User');
+	store.setLoginInfo({ id: 'myUserId', name: 'User' });
 	store.addRooms([room]);
 	store.addMeetings([meeting]);
 });

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingParticipantHandRaisedEventHandler.test.tsx
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingParticipantHandRaisedEventHandler.test.tsx
@@ -39,7 +39,7 @@ const lowerEvent: MeetingParticipantHandRaisedEvent = {
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo('myUserId', 'User');
+	store.setLoginInfo({ id: 'myUserId', name: 'User' });
 	store.addRooms([room]);
 	store.addMeetings([meeting]);
 });

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingParticipantSubscribedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingParticipantSubscribedEventHandler.test.ts
@@ -24,7 +24,7 @@ const event: MeetingParticipantSubscribedEvent = {
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo('myUserId', 'User');
+	store.setLoginInfo({ id: 'myUserId', name: 'User' });
 	store.addRooms([room]);
 	store.addMeetings([meeting]);
 });

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingParticipantTalkingHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingParticipantTalkingHandler.test.ts
@@ -22,7 +22,7 @@ const event: MeetingParticipantTalkingEvent = {
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo('myUserId', 'User');
+	store.setLoginInfo({ id: 'myUserId', name: 'User' });
 	store.addRooms([room]);
 	store.addMeetings([meeting]);
 });

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingRecordingStartedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingRecordingStartedEventHandler.test.ts
@@ -28,7 +28,7 @@ const event: MeetingRecordingStartedEvent = {
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo('myUserId', 'User');
+	store.setLoginInfo({ id: 'myUserId', name: 'User' });
 	store.addRooms([room]);
 	store.addMeetings([meeting]);
 });

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingRecordingStoppedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingRecordingStoppedEventHandler.test.ts
@@ -28,7 +28,7 @@ const event: MeetingRecordingStoppedEvent = {
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo('myUserId', 'User');
+	store.setLoginInfo({ id: 'myUserId', name: 'User' });
 	store.addRooms([room]);
 	store.addMeetings([meeting]);
 });

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingSDPAnsweredEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingSDPAnsweredEventHandler.test.ts
@@ -27,7 +27,7 @@ const event: MeetingSDPAnsweredEvent = {
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo('myUserId', 'User');
+	store.setLoginInfo({ id: 'myUserId', name: 'User' });
 	store.addRooms([room]);
 	store.addMeetings([meeting]);
 });

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingSDPOfferedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingSDPOfferedEventHandler.test.ts
@@ -27,7 +27,7 @@ const event: MeetingSDPOfferedEvent = {
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo('myUserId', 'User');
+	store.setLoginInfo({ id: 'myUserId', name: 'User' });
 	store.addRooms([room]);
 	store.addMeetings([meeting]);
 });

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingStartedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingStartedEventHandler.test.ts
@@ -28,7 +28,7 @@ const event: MeetingStartedEvent = {
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo('myUserId', 'myusername');
+	store.setLoginInfo({ id: 'myUserId', name: 'User' });
 	store.addRooms([oneToOneRoom, groupRoom]);
 	store.addMeetings([oneToOneMeeting, groupMeeting]);
 });
@@ -49,7 +49,7 @@ describe('MeetingStartedEventHandler tests', () => {
 	});
 
 	test('Incoming meeting notification is not sent if the meeting is started by me', () => {
-		useStore.getState().setLoginInfo(event.starterUser, 'myusername');
+		useStore.getState().setLoginInfo({ id: event.starterUser, name: 'myusername' });
 		const dispatchEvent = vi.spyOn(window, 'dispatchEvent');
 		meetingStartedEventHandler(event);
 		expect(dispatchEvent).not.toHaveBeenCalled();

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingStoppedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingStoppedEventHandler.test.ts
@@ -39,7 +39,7 @@ const groupEvent: MeetingStoppedEvent = {
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo('myUserId', 'myusername');
+	store.setLoginInfo({ id: 'myUserId', name: 'User' });
 	store.addRooms([oneToOneRoom, groupRoom]);
 	store.addMeetings([oneToOneMeeting, groupMeeting]);
 });

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingUserAcceptedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingUserAcceptedEventHandler.test.ts
@@ -26,7 +26,7 @@ const event: MeetingUserAcceptedEvent = {
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo('myUserId', 'User');
+	store.setLoginInfo({ id: 'myUserId', name: 'User' });
 	store.addRooms([room]);
 	store.addMeetings([meeting]);
 	store.addUserToWaitingList(meeting.id, 'acceptedId');

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingUserRejectedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingUserRejectedEventHandler.test.ts
@@ -33,7 +33,7 @@ const iAmRejectedEvent: MeetingUserRejectedEvent = {
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo('myUserId', 'User');
+	store.setLoginInfo({ id: 'myUserId', name: 'User' });
 	store.addRooms([room]);
 	store.addMeetings([meeting]);
 	store.addUserToWaitingList(meeting.id, 'rejectedId');

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingWaitingParticipantClashedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingWaitingParticipantClashedEventHandler.test.ts
@@ -32,7 +32,7 @@ const event: MeetingWaitingParticipantClashed = {
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo('myUserId', 'User');
+	store.setLoginInfo({ id: 'myUserId', name: 'User' });
 	store.addRooms([room]);
 	store.addMeetings([meeting]);
 	store.addParticipant(meeting.id, createMockParticipants({ userId: 'myUserId' }));

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingWaitingParticipantJoinedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingWaitingParticipantJoinedEventHandler.test.ts
@@ -34,7 +34,7 @@ const event: MeetingWaitingParticipantJoinedEvent = {
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo('myUserId', 'User');
+	store.setLoginInfo({ id: 'myUserId', name: 'User' });
 	store.addRooms([room]);
 	store.addMeetings([meeting]);
 	store.addParticipant(meeting.id, createMockParticipants({ userId: 'myUserId' }));

--- a/src/network/xmpp/XMPPClient.ts
+++ b/src/network/xmpp/XMPPClient.ts
@@ -20,9 +20,15 @@ import { getLastUnreadMessage } from './utility/getLastUnreadMessage';
 import HistoryAccumulator from './utility/HistoryAccumulator';
 import { sanitizeXmppMessage } from './utility/sanitizeXmppMessage';
 import XMPPConnection, { XMPPRequestType } from './XMPPConnection';
+import { getEditAndDeleteFasteningSelector } from '../../store/selectors/ChatsRegistrySelectors';
 import useStore from '../../store/Store';
-import { MessageFastening, MessageType, TextMessage } from '../../types/store/ChatsRegistryTypes';
-import { dateToISODate } from '../../utils/dateUtils';
+import {
+	FasteningAction,
+	MessageFastening,
+	MessageType,
+	TextMessage
+} from '../../types/store/ChatsRegistryTypes';
+import { dateToISODate, dateToTimestamp } from '../../utils/dateUtils';
 
 const jabberData = 'jabber:x:data';
 
@@ -140,8 +146,83 @@ class XMPPClient {
 			type: XMPPRequestType.IQ,
 			elem: iq,
 			callback: () => {
-				const messages = HistoryAccumulator.getInboxMessages(queryId);
-				useStore.getState().newInboxMessages(messages);
+				const inboxMessages = HistoryAccumulator.getInboxMessages(queryId);
+				const filteredInbox = inboxMessages.filter((message) => {
+					const inboxMessageId = useStore.getState().chatsRegistry[message.roomId]?.inboxMessageId;
+					const cleanHistoryDate =
+						useStore.getState().rooms[message.roomId]?.userSettings?.clearedAt;
+					return (
+						(!inboxMessageId || message.id !== inboxMessageId) &&
+						(!cleanHistoryDate || message.date > dateToTimestamp(cleanHistoryDate))
+					);
+				});
+				if (filteredInbox.length === 0) return;
+
+				const { setInboxMessages, addFastening, setLastMessage } = useStore.getState();
+				setInboxMessages(filteredInbox);
+				const fastenings = filteredInbox.filter(
+					(message) => message.type === MessageType.FASTENING
+				);
+				if (fastenings.length > 0) {
+					addFastening(fastenings);
+					Promise.all(
+						fastenings.map(async (fastening) => {
+							let { date } = fastening;
+							while (true) {
+								const queryId = HistoryAccumulator.getNextId();
+								// eslint-disable-next-line no-await-in-loop
+								const resp = await this.requestMessages(queryId, fastening.roomId, date, 3);
+								if (!resp) return;
+								const messages = HistoryAccumulator.getHistoryMessages(queryId);
+								if (messages.length === 0) return;
+
+								const fasteningMessages = messages.filter(
+									(msg) => msg.type === MessageType.FASTENING
+								);
+								if (fasteningMessages.length > 0) {
+									addFastening(fasteningMessages);
+								}
+								const textOrConfig = messages.findLast(
+									(m) => m.type === MessageType.TEXT_MSG || m.type === MessageType.CONFIGURATION_MSG
+								);
+
+								if (textOrConfig) {
+									let newLastMessage = textOrConfig;
+									if (newLastMessage.type === MessageType.TEXT_MSG) {
+										const lastFastening = getEditAndDeleteFasteningSelector(
+											useStore.getState(),
+											fastening.roomId,
+											newLastMessage.stanzaId
+										);
+										if (lastFastening?.action === FasteningAction.EDIT) {
+											newLastMessage = {
+												...textOrConfig,
+												edited: true,
+												text: lastFastening.value ?? '',
+												editedStanzaId: fastening.stanzaId
+											} as TextMessage;
+										}
+										if (FasteningAction.DELETE === lastFastening?.action) {
+											newLastMessage = {
+												...textOrConfig,
+												deleted: true,
+												text: '',
+												attachment: undefined,
+												replyTo: undefined
+											} as TextMessage;
+										}
+									}
+									setLastMessage(newLastMessage.roomId, newLastMessage);
+									return;
+								}
+								date = messages.reduce(
+									(oldest, m) => (m.date < oldest ? m.date : oldest),
+									messages[0]?.date
+								);
+							}
+						})
+					);
+				}
 			}
 		});
 	}
@@ -260,6 +341,55 @@ class XMPPClient {
 			.c('body')
 			.t(reaction);
 		this.xmppConnection.send({ type: XMPPRequestType.MESSAGE, elem: msg });
+	}
+
+	public requestMessages(
+		queryId: string,
+		roomId: string,
+		endHistory: number,
+		quantity: number
+	): Promise<Element | null> {
+		return new Promise((resolve, reject) => {
+			if (!useStore.getState().rooms[roomId]) {
+				resolve(null);
+				return;
+			}
+
+			const clearedAt = useStore.getState().rooms[roomId]?.userSettings?.clearedAt;
+			const startHistory = clearedAt ?? useStore.getState().rooms[roomId]?.createdAt ?? 0;
+
+			const iq = $iq({ type: 'set', to: carbonizeMUC(roomId) })
+				.c('query', { xmlns: Strophe.NS.MAM, queryid: queryId })
+				.c('x', { type: 'submit', xmlns: jabberData })
+				.c('field', { var: 'FORM_TYPE', type: 'hidden' })
+				.c('value')
+				.t(Strophe.NS.MAM)
+				.up()
+				.up()
+				.c('field', { var: 'start' })
+				.c('value')
+				.t(dateToISODate(startHistory))
+				.up()
+				.up()
+				.c('field', { var: 'end' })
+				.c('value')
+				.t(dateToISODate(endHistory))
+				.up()
+				.up()
+				.up()
+				.c('set', { xmlns: Strophe.NS.RSM })
+				.c('max')
+				.t(String(quantity))
+				.up()
+				.c('before');
+
+			this.xmppConnection.send({
+				type: XMPPRequestType.IQ,
+				elem: iq,
+				callback: (stanza) => resolve(stanza),
+				errorCallback: reject
+			});
+		});
 	}
 
 	// Request n messages before end date but not before start date

--- a/src/network/xmpp/XMPPClient.ts
+++ b/src/network/xmpp/XMPPClient.ts
@@ -215,10 +215,7 @@ class XMPPClient {
 									setLastMessage(newLastMessage.roomId, newLastMessage);
 									return;
 								}
-								date = messages.reduce(
-									(oldest, m) => (m.date < oldest ? m.date : oldest),
-									messages[0]?.date
-								);
+								date = messages.reduce((oldest, m) => Math.min(m.date, oldest), messages[0]?.date);
 							}
 						})
 					);

--- a/src/network/xmpp/handlers/composingMessageHandler.test.ts
+++ b/src/network/xmpp/handlers/composingMessageHandler.test.ts
@@ -18,7 +18,7 @@ const mockedRoom = createMockRoom({
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo('myUserId', 'User');
+	store.setLoginInfo({ id: 'myUserId', name: 'User' });
 	store.addRooms([mockedRoom]);
 });
 

--- a/src/network/xmpp/handlers/inboxMessageHandler.test.ts
+++ b/src/network/xmpp/handlers/inboxMessageHandler.test.ts
@@ -5,12 +5,7 @@
  */
 
 import { onInboxMessageStanza } from './inboxMessageHandler';
-import useStore from '../../../store/Store';
-import {
-	buildReactionMessageFromInbox,
-	buildReplyMessageFromInbox,
-	buildTextMessageFromInbox
-} from '../../../tests/buildXmppStanza';
+import { buildTextMessageFromInbox } from '../../../tests/buildXmppStanza';
 import { createMockTextMessage } from '../../../tests/createMock';
 import { MessageType, TextMessage } from '../../../types/store/ChatsRegistryTypes';
 import HistoryAccumulator from '../utility/HistoryAccumulator';
@@ -34,7 +29,7 @@ describe('XMPP inboxMessageHandler tests', () => {
 		expect(textMessage.from).toBe(message.from);
 	});
 
-	test('Conversation has some unread', () => {
+	test('Conversation has some unread (< 15)', () => {
 		const spyOnRequestHistory = vi.spyOn(xmppClient, 'requestHistory');
 
 		const message = createMockTextMessage({ text: 'Hi!' });
@@ -47,32 +42,16 @@ describe('XMPP inboxMessageHandler tests', () => {
 		expect(spyOnRequestHistory).toHaveBeenCalled();
 	});
 
-	test('Inbox message is a replied one', () => {
-		const spyOnRequestRepliedMessage = vi.spyOn(xmppClient, 'requestMessageSubjectOfReply');
+	test('Conversation has a lot of unread', () => {
+		const spyOnRequestHistory = vi.spyOn(xmppClient, 'requestHistory');
 
 		const message = createMockTextMessage({ text: 'Hi!' });
-		const messageXMPP = buildReplyMessageFromInbox({
+		const messageXMPP = buildTextMessageFromInbox({
 			roomId: message.roomId,
-			replyToStanzaId: '1234'
+			unread: 30
 		});
 		onInboxMessageStanza.call(xmppClient, messageXMPP);
 
-		expect(spyOnRequestRepliedMessage).toHaveBeenCalledTimes(1);
-	});
-
-	test('Inbox message is a fastening', () => {
-		const message = createMockTextMessage({ text: 'Hi!' });
-		const messageXMPP = buildReactionMessageFromInbox({
-			roomId: message.roomId,
-			from: message.from,
-			originalStanzaId: message.stanzaId,
-			reaction: '👍'
-		});
-		onInboxMessageStanza.call(xmppClient, messageXMPP);
-
-		const fastenings =
-			useStore.getState().chatsRegistry[message.roomId].fastenings[message.stanzaId];
-		expect(fastenings[0].type).toBe(MessageType.FASTENING);
-		expect(fastenings[0].value).toBe('👍');
+		expect(spyOnRequestHistory).not.toHaveBeenCalled();
 	});
 });

--- a/src/network/xmpp/handlers/inboxMessageHandler.ts
+++ b/src/network/xmpp/handlers/inboxMessageHandler.ts
@@ -24,47 +24,31 @@ export function onInboxMessageStanza(message: Element): true {
 	const inboxMessage = decodeXMPPMessageStanza(insideMessage, { date: dateToTimestamp(date) });
 	const queryid = getRequiredAttribute(result, 'queryid');
 
-	if (inboxMessage) {
-		const store = useStore.getState();
-		xmppClient.lastMarkers(inboxMessage.roomId);
+	if (!inboxMessage) return true;
+	HistoryAccumulator.pushToCache(queryid, inboxMessage);
 
-		// Request history to count the real number of unread messages
-		const unreadMessages = getAttribute(result, 'unread');
-		if (unreadMessages && parseInt(unreadMessages, 10) > 0) {
-			const unreadCount = parseInt(unreadMessages, 10);
+	const store = useStore.getState();
+	// Handle initial unread count
+	const unreadMessages = getAttribute(result, 'unread');
+	if (unreadMessages && parseInt(unreadMessages, 10) > 0) {
+		const unreadCount = parseInt(unreadMessages, 10);
+		// Avoid to request history if the unread count is too high, to prevent performance issues
+		if (unreadCount < 15) {
 			xmppClient.requestHistory(
 				inboxMessage.roomId,
 				inboxMessage.date,
 				unreadCount + 1,
 				unreadCount
 			);
-		}
-
-		switch (inboxMessage.type) {
-			case MessageType.TEXT_MSG:
-				HistoryAccumulator.pushToCache(queryid, inboxMessage);
-
-				// Request message subject of reply
-				if (inboxMessage.replyTo) {
-					xmppClient.requestMessageSubjectOfReply(
-						inboxMessage.roomId,
-						inboxMessage.replyTo,
-						inboxMessage.id
-					);
-				}
-				break;
-			case MessageType.CONFIGURATION_MSG: {
-				HistoryAccumulator.pushToCache(queryid, inboxMessage);
-				break;
-			}
-			case MessageType.FASTENING:
-				store.addFastening([inboxMessage]);
-				// Last inboxMessage is a fastening, we need to request more messages to display the real last one
-				xmppClient.requestHistory(inboxMessage.roomId, inboxMessage.date, 3);
-				break;
-			default:
-				break;
+		} else {
+			store.setUnreadCount(inboxMessage.roomId, unreadCount);
 		}
 	}
+
+	// Request marker to display the right read status
+	if (inboxMessage.type === MessageType.TEXT_MSG && inboxMessage.from === store.session.id) {
+		xmppClient.lastMarkers(inboxMessage.roomId);
+	}
+
 	return true;
 }

--- a/src/network/xmpp/handlers/newMessageHandler.test.ts
+++ b/src/network/xmpp/handlers/newMessageHandler.test.ts
@@ -159,7 +159,7 @@ describe('XMPP newMessageHandler', () => {
 		const otherUser = createMockUser({ id: 'otherUser' });
 		const room = createMockRoom({ id: 'roomId' });
 		const store = useStore.getState();
-		store.setLoginInfo(sessionUser.id, sessionUser.name || '');
+		store.setLoginInfo({ id: sessionUser.id, name: sessionUser.name });
 		store.setUserInfo([otherUser]);
 		store.addRooms([room]);
 		const myMessage = createMockTextMessage({
@@ -188,7 +188,7 @@ describe('XMPP newMessageHandler', () => {
 		const otherUser = createMockUser({ id: 'otherUser2' });
 		const room = createMockRoom({ id: 'roomId2' });
 		const store = useStore.getState();
-		store.setLoginInfo(sessionUser.id, sessionUser.name || '');
+		store.setLoginInfo({ id: sessionUser.id, name: sessionUser.name });
 		store.setUserInfo([otherUser]);
 		store.addRooms([room]);
 		const myMessage = createMockTextMessage({

--- a/src/network/xmpp/handlers/newMessageHandler.ts
+++ b/src/network/xmpp/handlers/newMessageHandler.ts
@@ -67,11 +67,17 @@ export function onNewMessageStanza(message: Element): true {
 			}
 			if (newMessage.operation === OperationType.MESSAGE_UNPINNED) {
 				store.removePinnedMessage(newMessage.roomId);
+				store.setSelectedPinnedMessage(newMessage.roomId, undefined);
+			}
+			// Mark message as read if the message configuration is sent after user action
+			if (newMessage.from === sessionId) {
+				xmppClient.readMessage(newMessage.roomId, newMessage.id);
 			}
 			break;
 		}
 		case MessageType.FASTENING: {
 			store.addFastening([newMessage]);
+
 			// Update lastMessage
 			const lastMessage = store.chatsRegistry[newMessage.roomId]?.lastMessage;
 			if (
@@ -97,13 +103,6 @@ export function onNewMessageStanza(message: Element): true {
 					} as TextMessage);
 				}
 			}
-			// const pinnedMessage = getPinnedMessage(store, newMessage.roomId);
-			// if (
-			// 	newMessage.action === FasteningAction.DELETE &&
-			// 	pinnedMessage?.stanzaId === newMessage.originalStanzaId
-			// ) {
-			// 	store.removePinnedMessage(newMessage.roomId);
-			// }
 			if (newMessage.action === FasteningAction.REACTION && newMessage.from !== sessionId) {
 				displayReactionBrowserNotification(newMessage);
 				store.setNewReaction(

--- a/src/network/xmpp/handlers/newMessageHandler.ts
+++ b/src/network/xmpp/handlers/newMessageHandler.ts
@@ -5,12 +5,12 @@
  */
 
 import { EventName, sendCustomEvent } from '../../../hooks/useEventListener';
-import { getPinnedMessage } from '../../../store/selectors/ActiveConversationsSelectors';
 import useStore from '../../../store/Store';
 import {
 	FasteningAction,
 	MessageType,
-	OperationType
+	OperationType,
+	TextMessage
 } from '../../../types/store/ChatsRegistryTypes';
 import { getTagElement } from '../utility/decodeStanza';
 import { decodeXMPPMessageStanza } from '../utility/decodeXMPPMessageStanza';
@@ -27,6 +27,7 @@ export function onNewMessageStanza(message: Element): true {
 	const store = useStore.getState();
 	const sessionId: string | undefined = useStore.getState().session.id;
 
+	store.setInboxMessages([newMessage]);
 	switch (newMessage.type) {
 		case MessageType.TEXT_MSG: {
 			store.newMessage(newMessage);
@@ -71,13 +72,38 @@ export function onNewMessageStanza(message: Element): true {
 		}
 		case MessageType.FASTENING: {
 			store.addFastening([newMessage]);
-			const pinnedMessage = getPinnedMessage(store, newMessage.roomId);
+			// Update lastMessage
+			const lastMessage = store.chatsRegistry[newMessage.roomId]?.lastMessage;
 			if (
-				newMessage.action === FasteningAction.DELETE &&
-				pinnedMessage?.stanzaId === newMessage.originalStanzaId
+				[FasteningAction.EDIT, FasteningAction.DELETE].includes(newMessage.action) &&
+				lastMessage?.type === MessageType.TEXT_MSG &&
+				newMessage.originalStanzaId === lastMessage.stanzaId
 			) {
-				store.removePinnedMessage(newMessage.roomId);
+				if (newMessage.action === FasteningAction.DELETE) {
+					store.setLastMessage(newMessage.roomId, {
+						...lastMessage,
+						deleted: true,
+						text: '',
+						attachment: undefined,
+						replyTo: undefined
+					} as TextMessage);
+				}
+				if (newMessage.action === FasteningAction.EDIT) {
+					store.setLastMessage(newMessage.roomId, {
+						...lastMessage,
+						edited: true,
+						text: newMessage.value ?? '',
+						attachment: lastMessage.attachment
+					} as TextMessage);
+				}
 			}
+			// const pinnedMessage = getPinnedMessage(store, newMessage.roomId);
+			// if (
+			// 	newMessage.action === FasteningAction.DELETE &&
+			// 	pinnedMessage?.stanzaId === newMessage.originalStanzaId
+			// ) {
+			// 	store.removePinnedMessage(newMessage.roomId);
+			// }
 			if (newMessage.action === FasteningAction.REACTION && newMessage.from !== sessionId) {
 				displayReactionBrowserNotification(newMessage);
 				store.setNewReaction(

--- a/src/network/xmpp/handlers/presenceHandler.test.ts
+++ b/src/network/xmpp/handlers/presenceHandler.test.ts
@@ -15,7 +15,7 @@ const mockUser = createMockUser({ id: 'userId-mock', name: 'User Mock' });
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo(loggedUser.id, loggedUser.name);
+	store.setLoginInfo({ id: loggedUser.id, name: loggedUser.name });
 	store.setUserInfo([mockUser]);
 });
 

--- a/src/network/xmpp/utility/displayMessageBrowserNotification.test.ts
+++ b/src/network/xmpp/utility/displayMessageBrowserNotification.test.ts
@@ -17,7 +17,7 @@ const user = createMockUser({ id: 'userId', name: 'User' });
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo(loggedUser.id, loggedUser.name);
+	store.setLoginInfo({ id: loggedUser.id, name: loggedUser.name });
 	store.setUserInfo([user]);
 	store.addRooms([room]);
 });

--- a/src/network/xmpp/utility/displayReactionBrowserNotification.test.ts
+++ b/src/network/xmpp/utility/displayReactionBrowserNotification.test.ts
@@ -34,7 +34,7 @@ const messageFromUser = createMockTextMessage({
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo(loggedUser.id, loggedUser.name);
+	store.setLoginInfo({ id: loggedUser.id, name: loggedUser.name });
 	store.setUserInfo([user]);
 	store.addRooms([room]);
 	store.newMessage(messageFromMe);

--- a/src/network/xmpp/utility/getLastUnreadMessage.test.ts
+++ b/src/network/xmpp/utility/getLastUnreadMessage.test.ts
@@ -55,22 +55,6 @@ describe('getLastUnreadMessage', () => {
 			expect(getLastUnreadMessage(room.id)).toBe(message.id);
 		});
 
-		test('Conversation has only the inbox message sent by me', () => {
-			const message = createMockTextMessage({ roomId: room.id, from: sessionUser.id });
-			const store = useStore.getState();
-			store.newInboxMessages([message]);
-
-			expect(getLastUnreadMessage(room.id)).toBe(undefined);
-		});
-
-		test('Conversation has only the inbox message sent by another user', () => {
-			const message = createMockTextMessage({ roomId: room.id, from: user1.id });
-			const store = useStore.getState();
-			store.newInboxMessages([message]);
-
-			expect(getLastUnreadMessage(room.id)).toBe(message.id);
-		});
-
 		test('Conversation has only text messages sent by me', () => {
 			const message1 = createMockTextMessage({
 				roomId: room.id,

--- a/src/network/xmpp/utility/getLastUnreadMessage.test.ts
+++ b/src/network/xmpp/utility/getLastUnreadMessage.test.ts
@@ -33,7 +33,7 @@ const myMarker = createMockMarker({
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo(sessionUser.id, sessionUser.name);
+	store.setLoginInfo({ id: sessionUser.id, name: sessionUser.name });
 	store.addRooms([room]);
 });
 describe('getLastUnreadMessage', () => {

--- a/src/settings/components/Settings.test.tsx
+++ b/src/settings/components/Settings.test.tsx
@@ -44,7 +44,7 @@ const dataTestid = 'data-testid';
 beforeEach(() => {
 	const store: RootStore = useStore.getState();
 	store.setUserInfo([user1]);
-	store.setLoginInfo(user1.id, user1.name, user1.name);
+	store.setLoginInfo({ id: user1.id, name: user1.name, displayName: user1.name });
 });
 describe('Settings view', () => {
 	describe('Notifications Settings', () => {

--- a/src/settings/components/chatExporter/ChatItem.test.tsx
+++ b/src/settings/components/chatExporter/ChatItem.test.tsx
@@ -62,7 +62,7 @@ describe('ChatItem test', () => {
 			text: 'Last message',
 			from: otherUser.id
 		});
-		useStore.getState().newMessage(message);
+		useStore.getState().setInboxMessages([message]);
 		setup(<ChatItem roomId={singleRoom.id} onClick={vi.fn()} />);
 		const lastMessage = screen.getByText(`Other: ${message.text}`);
 		expect(lastMessage).toBeInTheDocument();
@@ -75,7 +75,7 @@ describe('ChatItem test', () => {
 			from: otherUser.id,
 			deleted: true
 		});
-		useStore.getState().newMessage(message);
+		useStore.getState().setInboxMessages([message]);
 		setup(<ChatItem roomId={singleRoom.id} onClick={vi.fn()} />);
 		const lastMessage = screen.getByText('Deleted message');
 		expect(lastMessage).toBeInTheDocument();
@@ -88,7 +88,7 @@ describe('ChatItem test', () => {
 			attachment: { id: 'file', name: 'Attachment.txt', mimeType: 'txt', size: 2300 },
 			from: otherUser.id
 		});
-		useStore.getState().newMessage(message);
+		useStore.getState().setInboxMessages([message]);
 		setup(<ChatItem roomId={singleRoom.id} onClick={vi.fn()} />);
 		const lastMessage = screen.getByText(`Other: ${message.attachment!.name}`);
 		expect(lastMessage).toBeInTheDocument();
@@ -101,7 +101,7 @@ describe('ChatItem test', () => {
 			value: 'newName',
 			from: otherUser.id
 		});
-		useStore.getState().newMessage(message);
+		useStore.getState().setInboxMessages([message]);
 		setup(<ChatItem roomId={singleRoom.id} onClick={vi.fn()} />);
 		const lastMessage = screen.getByText('Other User changed the title of this Group in .');
 		expect(lastMessage).toBeInTheDocument();

--- a/src/settings/components/chatExporter/ChatItem.test.tsx
+++ b/src/settings/components/chatExporter/ChatItem.test.tsx
@@ -39,7 +39,7 @@ const groupRoom = createMockRoom({
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo(loggedUser.id, loggedUser.name);
+	store.setLoginInfo({ id: loggedUser.id, name: loggedUser.name });
 	store.setUserInfo([loggedUser, otherUser]);
 	store.addRooms([singleRoom, groupRoom]);
 });

--- a/src/settings/components/chatExporter/ChatItem.tsx
+++ b/src/settings/components/chatExporter/ChatItem.tsx
@@ -9,8 +9,7 @@ import { Avatar, Container, Row, Spinner, Text } from '@zextras/carbonio-design-
 import { useTranslation } from 'react-i18next';
 
 import { ConfigurationMessageLabel } from '../../../hooks/useConfigurationMessageLabel';
-import useMessage from '../../../hooks/useMessage';
-import { getLastMessageIdSelector } from '../../../store/selectors/ChatsRegistrySelectors';
+import { getLastMessageSelector } from '../../../store/selectors/ChatsRegistrySelectors';
 import {
 	getRoomNameSelector,
 	getRoomTypeSelector,
@@ -19,7 +18,7 @@ import {
 import { getExportedChat, getUserId } from '../../../store/selectors/SessionSelectors';
 import { getUserName } from '../../../store/selectors/UsersSelectors';
 import useStore from '../../../store/Store';
-import { Message, MessageType } from '../../../types/store/ChatsRegistryTypes';
+import { MessageType } from '../../../types/store/ChatsRegistryTypes';
 import { RoomType } from '../../../types/store/RoomTypes';
 
 type ChatItemProps = {
@@ -35,8 +34,7 @@ const ChatItem: React.FC<ChatItemProps> = ({ roomId, onClick }: ChatItemProps) =
 	const roomName = useStore((store) => getRoomNameSelector(store, roomId));
 	const roomType = useStore((store) => getRoomTypeSelector(store, roomId));
 	const exportedChat = useStore(getExportedChat);
-	const lastMessageId = useStore((state) => getLastMessageIdSelector(state, roomId));
-	const lastMessageOfRoom: Message | undefined = useMessage(roomId, lastMessageId ?? '');
+	const lastMessageOfRoom = useStore((state) => getLastMessageSelector(state, roomId));
 	const userNameOfLastMessageOfRoom = useStore((store) =>
 		lastMessageOfRoom?.type === MessageType.TEXT_MSG
 			? getUserName(store, lastMessageOfRoom.from)

--- a/src/settings/views/SettingsView.test.tsx
+++ b/src/settings/views/SettingsView.test.tsx
@@ -14,7 +14,7 @@ import { setup } from '../../tests/test-utils';
 
 describe('SettingsView tests', () => {
 	test('SettingsView renders correctly if session user is loaded', () => {
-		useStore.getState().setLoginInfo('sessionId', 'Session User');
+		useStore.getState().setLoginInfo({ id: 'sessionId', name: 'Session User' });
 		setup(<SettingsView />);
 		expect(screen.getByTestId('settings_container')).toBeInTheDocument();
 	});

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -18,8 +18,7 @@ import { useUsersStoreSlice } from './slices/UsersStoreSlice';
 import { RootStore } from '../types/store/StoreTypes';
 
 const STORAGE_KEY = 'carbonio-ws-collaboration-storage';
-const TTL = 48 * 60 * 60 * 1000;
-
+const TTL = 2 * 24 * 60 * 60 * 1000;
 const checkAndCleanExpiredStorage = (): void => {
 	const stored = localStorage.getItem(STORAGE_KEY);
 	if (stored) {
@@ -47,7 +46,7 @@ const useStore = create<RootStore>()(
 				...useActiveMeetingSlice(set, get, api)
 			}),
 			{
-				name: 'carbonio-ws-collaboration-storage',
+				name: STORAGE_KEY,
 				partialize: (state) => ({
 					session: {
 						_persistedAt: state.session._persistedAt

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -56,6 +56,22 @@ const useStore = create<RootStore>()(
 							const { online, lastActivity, ...persistentUser } = user;
 							return [userId, persistentUser];
 						})
+					),
+					rooms: state.rooms,
+					chatsRegistry: Object.fromEntries(
+						Object.entries(state.chatsRegistry).map(([roomId, chat]) => [
+							roomId,
+							{
+								unread: 0,
+								inboxMessageId: chat.inboxMessageId,
+								lastMessage: chat.lastMessage,
+								messages: [],
+								fastenings: {},
+								markers: {},
+								searchResults: [],
+								backfillQueue: []
+							}
+						])
 					)
 				})
 			}

--- a/src/store/selectors/ChatsRegistrySelectors.ts
+++ b/src/store/selectors/ChatsRegistrySelectors.ts
@@ -56,27 +56,10 @@ export const getReadableMessagesSelector = (
 	return readableMessages;
 };
 
-export const getLastTextMessageIdSelector = (
+export const getLastMessageSelector = (
 	store: RootStore,
 	roomId: string
-): string | undefined => {
-	const textMessages = filter(
-		store.chatsRegistry[roomId]?.messages,
-		(message) => message.type === MessageType.TEXT_MSG
-	);
-	if (textMessages && textMessages[textMessages.length - 1]) {
-		return textMessages[textMessages.length - 1].id;
-	}
-	return undefined;
-};
-
-export const getLastMessageIdSelector = (store: RootStore, roomId: string): string | undefined => {
-	const messages = store.chatsRegistry[roomId]?.messages;
-	if (messages?.[messages.length - 1]) {
-		return messages[messages.length - 1].id;
-	}
-	return undefined;
-};
+): TextMessage | ConfigurationMessage | undefined => store.chatsRegistry[roomId]?.lastMessage;
 
 export const getMessageSelector = (
 	store: RootStore,

--- a/src/store/selectors/chatsRegistrySelectors/useOrderedRoomsInfoByLastMessage.tsx
+++ b/src/store/selectors/chatsRegistrySelectors/useOrderedRoomsInfoByLastMessage.tsx
@@ -22,8 +22,7 @@ export const useOrderedRoomsInfoByLastMessage = (): FilteredConversation[] => {
 			);
 
 			return filteredRooms.map((room) => {
-				const messages = state.chatsRegistry[room.id]?.messages;
-				const lastMessageDate = messages?.[messages.length - 1]?.date ?? 0;
+				const lastMessageDate = state.chatsRegistry[room.id]?.lastMessage?.date ?? 0;
 				const draftMessageDate = state.activeConversations[room.id]?.draftMessage?.date ?? 0;
 
 				return {

--- a/src/store/slices/ActiveConversationsSlice.test.ts
+++ b/src/store/slices/ActiveConversationsSlice.test.ts
@@ -26,7 +26,7 @@ const mockedRoom = createMockRoom({
 
 beforeEach(() => {
 	const store = useStore.getState();
-	store.setLoginInfo(sessionUser.id, sessionUser.name);
+	store.setLoginInfo({ id: sessionUser.id, name: sessionUser.name });
 	store.addRooms([mockedRoom]);
 });
 

--- a/src/store/slices/ChatsRegistryStoreSlice.test.ts
+++ b/src/store/slices/ChatsRegistryStoreSlice.test.ts
@@ -80,11 +80,11 @@ describe('ChatsRegistryStoreSlice tests', () => {
 	describe('newInboxMessage', () => {
 		test('Arrive an inbox text message', () => {
 			const inboxMessage = createMockTextMessage();
-			useStore.getState().newInboxMessages([inboxMessage]);
+			useStore.getState().setInboxMessages([inboxMessage]);
 
-			const { messages } = useStore.getState().chatsRegistry[newTextMessage.roomId];
-			expect(messages).toHaveLength(1);
-			expect(messages[0]).toBe(inboxMessage);
+			const { messages, lastMessage } = useStore.getState().chatsRegistry[newTextMessage.roomId];
+			expect(messages).toHaveLength(0);
+			expect(lastMessage).toBe(inboxMessage);
 		});
 
 		test('Arrive an inbox text message after a history request', () => {
@@ -93,32 +93,13 @@ describe('ChatsRegistryStoreSlice tests', () => {
 				date: dateToTimestamp('2024-05-01 13:01:05')
 			});
 			useStore.getState().updateHistory(inboxMessage.roomId, [textMessage0, textMessage1]);
-			useStore.getState().newInboxMessages([inboxMessage]);
+			useStore.getState().setInboxMessages([inboxMessage]);
 
 			const { messages } = useStore.getState().chatsRegistry[inboxMessage.roomId];
 			// Messages list: [MESSAGE0, MESSAGE1]]
 			expect(messages).toHaveLength(2);
 			expect(messages[0]).toBe(textMessage0);
 			expect(messages[1]).toBe(textMessage1);
-		});
-
-		test('Arrive an inbox message of a room in which history is been cleared before message date', () => {
-			const room = createMockRoom({
-				userSettings: {
-					muted: false,
-					clearedAt: dateToISODate(date1)
-				}
-			});
-			const inboxMessage = createMockTextMessage({
-				roomId: room.id,
-				date: date2
-			});
-			useStore.getState().addRooms([room]);
-			useStore.getState().newInboxMessages([inboxMessage]);
-
-			// Messages list: [DATE, INBOX MESSAGE]
-			const { messages } = useStore.getState().chatsRegistry[inboxMessage.roomId];
-			expect(messages[0]).toStrictEqual(inboxMessage);
 		});
 
 		test('Arrive an inbox message of a room in which history is been cleared after message date', () => {
@@ -133,7 +114,7 @@ describe('ChatsRegistryStoreSlice tests', () => {
 				date: date1
 			});
 			useStore.getState().addRooms([room]);
-			useStore.getState().newInboxMessages([inboxMessage]);
+			useStore.getState().setInboxMessages([inboxMessage]);
 
 			const { messages } = useStore.getState().chatsRegistry[inboxMessage.roomId];
 			// Messages list: []
@@ -143,29 +124,14 @@ describe('ChatsRegistryStoreSlice tests', () => {
 
 	describe('updateHistory', () => {
 		test('First update history after an inbox message', () => {
-			useStore.getState().newInboxMessages([newTextMessage]);
+			useStore.getState().setInboxMessages([newTextMessage]);
 			useStore.getState().updateHistory(newTextMessage.roomId, [textMessage0, textMessage1]);
 
 			const { messages } = useStore.getState().chatsRegistry[newTextMessage.roomId];
 			// Messages list: [MESSAGE0, MESSAGE1, INBOX MESSAGE]
-			expect(messages).toHaveLength(3);
+			expect(messages).toHaveLength(2);
 			expect(messages[0]).toBe(textMessage0);
 			expect(messages[1]).toBe(textMessage1);
-			expect(messages[2]).toBe(newTextMessage);
-		});
-
-		test('Last message of history is the inbox message', () => {
-			const inboxMessage = createMockTextMessage({
-				id: 'newMessage',
-				date: dateToTimestamp('2024-05-01 14:04')
-			});
-			useStore.getState().newInboxMessages([inboxMessage]);
-			useStore.getState().updateHistory(inboxMessage.roomId, [textMessage0, inboxMessage]);
-
-			const { messages } = useStore.getState().chatsRegistry[inboxMessage.roomId];
-			// Messages list: [MESSAGE0, INBOX MESSAGE]
-			expect(messages).toHaveLength(2);
-			expect(messages[1]).toBe(inboxMessage);
 		});
 
 		test('Load a history after another history', () => {

--- a/src/store/slices/ChatsRegistryStoreSlice.ts
+++ b/src/store/slices/ChatsRegistryStoreSlice.ts
@@ -140,21 +140,31 @@ export const useChatsRegistryStoreSlice: StateCreator<
 			'CHAT/NEW_MESSAGE'
 		);
 	},
-	newInboxMessages: (inbox: Message[]): void => {
+	setInboxMessages: (inbox: Message[]): void => {
 		set(
 			produce((draft: RootStore) => {
 				inbox.forEach((message) => {
-					const { messages } = initRoomChatsRegistry(draft, message.roomId);
-					const alreadyExists = find(messages, { id: message.id });
-					const clearedAt = draft.rooms[message.roomId]?.userSettings?.clearedAt;
-					// Add message only if it doesn't already exist and the history is not cleared
-					if (!alreadyExists && (!clearedAt || isBefore(clearedAt, message.date))) {
-						messages.push(message);
+					const registry = initRoomChatsRegistry(draft, message.roomId);
+					registry.inboxMessageId = message.id;
+					if (
+						message.type === MessageType.TEXT_MSG ||
+						message.type === MessageType.CONFIGURATION_MSG
+					) {
+						registry.lastMessage = message;
 					}
 				});
 			}),
 			false,
 			'CHAT/NEW_INBOX_MESSAGE'
+		);
+	},
+	setLastMessage: (roomId: string, message: TextMessage | ConfigurationMessage): void => {
+		set(
+			produce((draft: RootStore) => {
+				initRoomChatsRegistry(draft, roomId).lastMessage = message;
+			}),
+			false,
+			'CHAT/SET_LAST_MESSAGE'
 		);
 	},
 	updateHistory: (roomId: string, messageArray: Message[]): void => {
@@ -175,9 +185,10 @@ export const useChatsRegistryStoreSlice: StateCreator<
 	addCreateRoomMessage: (roomId: string): void => {
 		set(
 			produce((draft: RootStore) => {
-				const { messages } = draft.chatsRegistry[roomId];
 				const room = draft.rooms[roomId];
+				if (!room) return;
 
+				const { messages } = initRoomChatsRegistry(draft, roomId);
 				const alreadyHasCreationMsg = some(
 					messages,
 					(message) =>
@@ -204,7 +215,7 @@ export const useChatsRegistryStoreSlice: StateCreator<
 						from: '',
 						read: MarkerStatus.READ
 					};
-					draft.chatsRegistry[roomId].messages.splice(0, 0, creationMsg);
+					messages.splice(0, 0, creationMsg);
 				}
 			}),
 			false,
@@ -271,7 +282,7 @@ export const useChatsRegistryStoreSlice: StateCreator<
 				}
 
 				// Add message to the end of list or replace a placeholder message
-				draft.chatsRegistry[roomId].messages.push(placeholderMessage);
+				messages.push(placeholderMessage);
 
 				sendCustomEvent({ name: EventName.NEW_MESSAGE, data: placeholderMessage });
 			}),
@@ -305,7 +316,7 @@ export const useChatsRegistryStoreSlice: StateCreator<
 	updateReadStatus: (roomId: string, newMarkers: Marker[]): void => {
 		set(
 			produce((draft: RootStore) => {
-				const { messages, markers } = initRoomChatsRegistry(draft, roomId);
+				const { messages, markers, lastMessage } = initRoomChatsRegistry(draft, roomId);
 
 				// Set a member marker only when it's a new marker, or it is more recent than other
 				forEach(newMarkers, (marker) => {
@@ -314,6 +325,15 @@ export const useChatsRegistryStoreSlice: StateCreator<
 						markers[marker.from] = marker;
 					}
 				});
+
+				// Update last message read status
+				if (
+					lastMessage &&
+					[MessageType.TEXT_MSG, MessageType.CONFIGURATION_MSG].includes(lastMessage.type) &&
+					[MarkerStatus.UNREAD, MarkerStatus.READ_BY_SOMEONE].includes(lastMessage.read)
+				) {
+					lastMessage.read = calcReads(lastMessage.date, roomId, markers);
+				}
 
 				// Update messages' read status of TEXT and CONFIGURATION messages
 				draft.chatsRegistry[roomId].messages = map(messages, (msg) => {
@@ -328,7 +348,7 @@ export const useChatsRegistryStoreSlice: StateCreator<
 
 				// Recalculate unread count
 				const myId = draft.session.id;
-				const myMarker = myId ? draft.chatsRegistry[roomId].markers[myId] : undefined;
+				const myMarker = myId ? draft.chatsRegistry[roomId]?.markers[myId] : undefined;
 				const lastMarkedDate = myMarker
 					? (find(messages, { id: myMarker.messageId })?.date ?? myMarker.markerDate)
 					: undefined;
@@ -345,6 +365,15 @@ export const useChatsRegistryStoreSlice: StateCreator<
 			}),
 			false,
 			'CHAT/UPDATE_READ_STATUS'
+		);
+	},
+	setUnreadCount: (roomId: string, count: number): void => {
+		set(
+			produce((draft: RootStore) => {
+				initRoomChatsRegistry(draft, roomId).unread = count;
+			}),
+			false,
+			'CHAT/SET_UNREAD_COUNT'
 		);
 	},
 	incrementUnreadCount: (roomId: string, counter: number): void => {

--- a/src/store/slices/ConnectionsStoreSlice.test.ts
+++ b/src/store/slices/ConnectionsStoreSlice.test.ts
@@ -57,7 +57,7 @@ describe('Connections slice', () => {
 
 		// API effects to store
 		act(() => {
-			result.current.setLoginInfo('userId', 'User');
+			result.current.setLoginInfo({ id: 'userId', name: 'User' });
 			result.current.setUserInfo([user]);
 			result.current.addRooms([room1, room2]);
 		});
@@ -66,7 +66,7 @@ describe('Connections slice', () => {
 
 		// XMPP effects to store
 		act(() => {
-			result.current.setLoginInfo('userId', 'User');
+			result.current.setLoginInfo({ id: 'userId', name: 'User' });
 			result.current.setUserInfo([user]);
 			result.current.newInboxMessages([message1]);
 			result.current.updateHistory(room1.id, [message1]);

--- a/src/store/slices/ConnectionsStoreSlice.test.ts
+++ b/src/store/slices/ConnectionsStoreSlice.test.ts
@@ -68,7 +68,7 @@ describe('Connections slice', () => {
 		act(() => {
 			result.current.setLoginInfo({ id: 'userId', name: 'User' });
 			result.current.setUserInfo([user]);
-			result.current.newInboxMessages([message1]);
+			result.current.setInboxMessages([message1]);
 			result.current.updateHistory(room1.id, [message1]);
 			result.current.updateHistory(room2.id, [message2]);
 			result.current.updateReadStatus(room1.id, [marker1]);

--- a/src/store/slices/RoomsStoreSlice.ts
+++ b/src/store/slices/RoomsStoreSlice.ts
@@ -35,12 +35,12 @@ export const useRoomsStoreSlice: StateCreator<
 				// Remove rooms that no longer exist on the server (skip placeholders)
 				forEach(Object.keys(draft.rooms), (roomId) => {
 					if (!incomingIds.has(roomId) && !draft.rooms[roomId]?.placeholder) {
+						const meetingId = getMeetingIdFromRoom(draft, roomId);
+						if (meetingId) delete draft.meetings[meetingId];
+
 						delete draft.rooms[roomId];
 						delete draft.activeConversations[roomId];
 						delete draft.chatsRegistry[roomId];
-
-						const meetingId = getMeetingIdFromRoom(draft, roomId);
-						if (meetingId) delete draft.meetings[meetingId];
 					}
 				});
 

--- a/src/store/slices/RoomsStoreSlice.ts
+++ b/src/store/slices/RoomsStoreSlice.ts
@@ -6,7 +6,7 @@
  */
 
 import { produce } from 'immer';
-import { filter, find, findLast, forEach, size, some } from 'lodash';
+import { filter, find, findLast, forEach, isEqual, size, some } from 'lodash';
 import { StateCreator } from 'zustand';
 
 import { MemberBe, RoomBe } from '../../types/network/models/roomBeTypes';
@@ -30,8 +30,23 @@ export const useRoomsStoreSlice: StateCreator<
 	addRooms: (roomsBe: RoomBe[]): void => {
 		set(
 			produce((draft: RootStore) => {
+				const incomingIds = new Set(roomsBe.map((r) => r.id));
+
+				// Remove rooms that no longer exist on the server (skip placeholders)
+				forEach(Object.keys(draft.rooms), (roomId) => {
+					if (!incomingIds.has(roomId) && !draft.rooms[roomId]?.placeholder) {
+						delete draft.rooms[roomId];
+						delete draft.activeConversations[roomId];
+						delete draft.chatsRegistry[roomId];
+
+						const meetingId = getMeetingIdFromRoom(draft, roomId);
+						if (meetingId) delete draft.meetings[meetingId];
+					}
+				});
+
+				// Add or update only changed rooms
 				forEach(roomsBe, (roomBe) => {
-					draft.rooms[roomBe.id] = {
+					const newRoom: Room = {
 						id: roomBe.id,
 						name: roomBe.name,
 						description: roomBe.description,
@@ -43,6 +58,11 @@ export const useRoomsStoreSlice: StateCreator<
 						userSettings: roomBe.userSettings,
 						meetingId: roomBe.meetingId ?? draft.rooms[roomBe.id]?.meetingId
 					};
+
+					const existingRoom = draft.rooms[roomBe.id];
+					if (!existingRoom || !isEqual(existingRoom, newRoom)) {
+						draft.rooms[roomBe.id] = newRoom;
+					}
 
 					// Remove messages sent before the clearedAt timestamp
 					const clearedAt = roomBe.userSettings?.clearedAt;
@@ -56,7 +76,7 @@ export const useRoomsStoreSlice: StateCreator<
 				});
 			}),
 			false,
-			'ROOMS/ADD_ROOMS'
+			'ROOMS/SYNC_ROOMS'
 		);
 	},
 	removeRoom: (roomId: string): void => {

--- a/src/store/slices/SessionStoreSlice.test.ts
+++ b/src/store/slices/SessionStoreSlice.test.ts
@@ -22,14 +22,16 @@ const groupRoom: RoomBe = createMockRoom({
 
 describe('SessionStoreSlice tests', () => {
 	test('loginInfo', () => {
-		useStore.getState().setLoginInfo('id', 'name', 'displayName');
-		expect(useStore.getState().session).toStrictEqual({
-			id: 'id',
-			name: 'name',
-			displayName: 'displayName',
-			userType: UserType.INTERNAL,
-			_persistedAt: expect.any(Number)
-		});
+		useStore.getState().setLoginInfo({ id: 'id', name: 'name', displayName: 'displayName' });
+		expect(useStore.getState().session).toEqual(
+			expect.objectContaining({
+				id: 'id',
+				name: 'name',
+				displayName: 'displayName',
+				userType: UserType.INTERNAL,
+				_persistedAt: expect.any(Number)
+			})
+		);
 	});
 
 	test('queueId', () => {

--- a/src/store/slices/SessionStoreSlice.ts
+++ b/src/store/slices/SessionStoreSlice.ts
@@ -14,6 +14,7 @@ import ChatExporter from '../../settings/components/chatExporter/ChatExporter';
 import {
 	AttributesList,
 	ExportStatus,
+	Session,
 	SessionStoreSlice,
 	Version
 } from '../../types/store/SessionTypes';
@@ -29,7 +30,15 @@ export const useSessionStoreSlice: StateCreator<
 	session: {
 		_persistedAt: Date.now()
 	},
-	setLoginInfo: (id: string, name: string, displayName?: string, userType?: UserType): void => {
+	setLoginInfo: ({
+		id,
+		name,
+		displayName,
+		userType,
+		zmAuthToken,
+		zxAuthToken,
+		server
+	}: Session): void => {
 		set(
 			produce((draft: RootStore) => {
 				draft.session = {
@@ -37,6 +46,9 @@ export const useSessionStoreSlice: StateCreator<
 					id,
 					name,
 					displayName,
+					zmAuthToken,
+					zxAuthToken,
+					server,
 					userType: userType ?? UserType.INTERNAL
 				};
 			}),
@@ -160,6 +172,26 @@ export const useSessionStoreSlice: StateCreator<
 			}),
 			false,
 			'SESSION/SET_SUPPORTED_VERSIONS'
+		);
+	},
+	reset: (): void => {
+		set(
+			produce((draft: RootStore) => {
+				draft.session = {
+					supportedVersions: draft.session.supportedVersions
+				};
+				draft.users = {};
+				draft.rooms = {};
+				draft.activeConversations = {};
+				draft.chatsRegistry = {};
+				draft.connections = {
+					status: {}
+				};
+				draft.meetings = {};
+				draft.activeMeeting = undefined;
+			}),
+			false,
+			'SESSION/RESET'
 		);
 	}
 });

--- a/src/types/store/ChatsRegistryTypes.ts
+++ b/src/types/store/ChatsRegistryTypes.ts
@@ -7,7 +7,8 @@
 export type ChatsRegistryStoreSlice = {
 	chatsRegistry: { [roomId: string]: ChatRegistry };
 	newMessage: (message: Message) => void;
-	newInboxMessages: (message: Message[]) => void;
+	setInboxMessages: (message: Message[]) => void;
+	setLastMessage: (roomId: string, message: TextMessage | ConfigurationMessage) => void;
 	updateHistory: (roomId: string, messageArray: Message[]) => void;
 	addCreateRoomMessage: (roomId: string) => void;
 	setRepliedMessage: (
@@ -19,6 +20,7 @@ export type ChatsRegistryStoreSlice = {
 	removePlaceholderMessage: (roomId: string, messageId: string) => void;
 	addFastening: (fasteningMessage: MessageFastening[]) => void;
 	updateReadStatus: (roomId: string, newMarkers: Marker[]) => void;
+	setUnreadCount: (roomId: string, count: number) => void;
 	incrementUnreadCount: (roomId: string, counter: number) => void;
 	setSearchResults: (roomId: string, results: TextMessage[]) => void;
 	clearSearchResults: (roomId: string) => void;
@@ -28,10 +30,12 @@ export type ChatsRegistryStoreSlice = {
 };
 
 export type ChatRegistry = {
+	unread: number;
+	inboxMessageId?: string;
+	lastMessage?: TextMessage | ConfigurationMessage;
 	messages: Message[];
 	fastenings: { [stanzaId: string]: MessageFastening[] };
 	markers: { [userId: string]: Marker };
-	unread: number;
 	searchResults: TextMessage[];
 	messageRanges?: MessageRange[];
 	backfillQueue: BackfillRequest[];

--- a/src/types/store/SessionTypes.ts
+++ b/src/types/store/SessionTypes.ts
@@ -11,7 +11,7 @@ import { IChatExporter } from '../../settings/components/chatExporter/ChatExport
 
 export type SessionStoreSlice = {
 	session: Session;
-	setLoginInfo: (id: string, name: string, displayName?: string, userType?: UserType) => void;
+	setLoginInfo: (session: Session) => void;
 	setAttributes: (attrs: AccountSettings['attrs']) => void;
 	setCapabilities: (capabilities: AttributesList) => void;
 	setQueueId: (queueId: string) => void;
@@ -21,6 +21,7 @@ export type SessionStoreSlice = {
 	setChatExportStatus: (status: ExportStatus) => void;
 	setApiVersion: (apiVersion: Version) => void;
 	setSupportedVersions: (versions: Version[]) => void;
+	reset: () => void;
 };
 
 export type Session = {
@@ -40,6 +41,9 @@ export type Session = {
 		exporter: IChatExporter;
 		status: ExportStatus;
 	};
+	zmAuthToken?: string; // Mobile field
+	zxAuthToken?: string; // Mobile field
+	server?: string; // Mobile field
 	_persistedAt?: number;
 };
 


### PR DESCRIPTION
Improve initial loading performance by persisting rooms and chat registry metadata (last message, inbox message) in local storage, so the sidebar can render immediately on app start without waiting for XMPP inbox results.

Main changes:
- **Dedicated lastMessage field:** `ConversationListItem` now reads from a dedicated `lastMessage` field in the chat registry instead of picking the last entry from the full messages array
- **Rooms persistence & sync**: Rooms data is persisted in local storage and fully synced on every getRooms API call
- **`setLoginInfo` accepts an object**: The setter now takes a Session object instead of positional arguments, also supporting mobile-specific fields
