### PR TITLE
feat: dispatch quota-changed event after attachment upload and refresh storages quota [CO-3460]

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	"scripts": {
 		"build": "sdk build",
 		"deploy": "sdk deploy",
+		"deploy:local": "sdk deploy --container ${CONTAINER:-carbonio-advanced-carbonio-composed-ui-1}",
 		"sdk-install": "sdk install",
 		"start": "sdk watch",
 		"test": "vitest run",

--- a/src/constants/appConstants.tsx
+++ b/src/constants/appConstants.tsx
@@ -20,6 +20,8 @@ export const MEETINGS_PATH = `focus-mode/${MEETINGS_ROUTE}/`;
 export const SOUND_NOTIFICATION_PARTICIPANT_THRESHOLD = 3;
 export const LARGE_MEETING_THRESHOLD = 15;
 
+export const QUOTA_CHANGED_EVENT = 'carbonio-ws-collaboration-ui:quota-changed';
+
 export const TRACKER_EVENT = {
 	meetingEvaluation: 'Meeting evaluation',
 	conversationSearch: 'Conversation search performed',

--- a/src/integrations/initIntegrations.tsx
+++ b/src/integrations/initIntegrations.tsx
@@ -5,10 +5,12 @@
  */
 import { useEffect } from 'react';
 
-import { registerComponents } from '@zextras/carbonio-shell-ui';
+import { getIntegratedFunction, registerComponents } from '@zextras/carbonio-shell-ui';
+import { debounce } from 'lodash';
 
 import CopyRoomWidget from './copyRoomIntegration/CopyRoomWidget';
 import SelectVirtualRoomWidgetComponent from './virtualRoomIntegration/SelectVirtualRoomWidget';
+import { QUOTA_CHANGED_EVENT } from '../constants/appConstants';
 import { getAttribute } from '../store/selectors/SessionSelectors';
 import useStore from '../store/Store';
 
@@ -29,5 +31,24 @@ export default function useIntegrationsApp(): void {
 			id: 'wsc-copy-room',
 			component: CopyRoomWidget
 		});
+	}, []);
+
+	useEffect(() => {
+		const debouncedRefreshQuota = debounce(() => {
+			const [refreshQuota, isAvailable] = getIntegratedFunction('storages-refresh-quota');
+			if (isAvailable) {
+				refreshQuota();
+			}
+		}, 2000);
+
+		const handler = (): void => {
+			debouncedRefreshQuota();
+		};
+
+		window.addEventListener(QUOTA_CHANGED_EVENT, handler);
+		return (): void => {
+			window.removeEventListener(QUOTA_CHANGED_EVENT, handler);
+			debouncedRefreshQuota.cancel();
+		};
 	}, []);
 }

--- a/src/network/apis/RoomsApi.test.ts
+++ b/src/network/apis/RoomsApi.test.ts
@@ -525,6 +525,30 @@ describe('Rooms API', () => {
 			);
 			dispatchSpy.mockRestore();
 		});
+
+		test('dispatches event even when some rooms fail (partial success)', async () => {
+			const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+			vi.spyOn(xmppClient, 'requestMessageToForward').mockImplementation(() => Promise.resolve());
+
+			const message = createMockTextMessage({
+				attachment: { id: 'att1', name: 'file.pdf', mimeType: applicationPdf, size: 1024 }
+			});
+			const xmlMessage = buildTextMessageFromHistory({
+				roomId: message.roomId,
+				from: message.from,
+				text: message.text
+			});
+			const insideMessage = xmlMessage.getElementsByTagName('message')[0];
+			vi.spyOn(HistoryAccumulator, 'getForwardedMessage').mockImplementation(() => insideMessage);
+
+			mockFetchAPI.mockResolvedValueOnce({}).mockRejectedValueOnce(new Error('network error'));
+
+			await expect(forwardMessages(['room1', 'room2'], [message])).rejects.toThrow();
+			expect(dispatchSpy).toHaveBeenCalledWith(
+				expect.objectContaining({ type: QUOTA_CHANGED_EVENT })
+			);
+			dispatchSpy.mockRestore();
+		});
 	});
 
 	test('replacePlaceholderRoom is called correctly', async () => {

--- a/src/network/apis/RoomsApi.test.ts
+++ b/src/network/apis/RoomsApi.test.ts
@@ -28,6 +28,7 @@ import {
 	updateRoom,
 	updateRoomPicture
 } from './RoomsApi';
+import { QUOTA_CHANGED_EVENT } from '../../constants/appConstants';
 import useStore from '../../store/Store';
 import { buildTextMessageFromHistory } from '../../tests/buildXmppStanza';
 import {
@@ -391,6 +392,51 @@ describe('Rooms API', () => {
 		});
 	});
 
+	describe('addRoomAttachment dispatches quota changed event', () => {
+		test('dispatches event on successful upload (legacy path)', async () => {
+			const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+			const store = useStore.getState();
+			store.setAttributes(createMockAttributesList({ carbonioWscMaxAttachmentSize: '100' }));
+			mockUploadFileFetchAPI.mockResolvedValueOnce({ id: 'fileId' });
+			const testFile = new File([], 'file.pdf', { type: applicationPdf });
+			const { signal } = new AbortController();
+			await addRoomAttachment(roomId, testFile, { area: '0x0' }, signal);
+			expect(dispatchSpy).toHaveBeenCalledWith(
+				expect.objectContaining({ type: QUOTA_CHANGED_EVENT })
+			);
+			dispatchSpy.mockRestore();
+		});
+
+		test('dispatches event on successful upload (1.6.1+ path)', async () => {
+			const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+			const store = useStore.getState();
+			store.setAttributes(createMockAttributesList({ carbonioWscMaxAttachmentSize: '100' }));
+			store.setApiVersion('1.6.1');
+			mockSendFileFetchAPI.mockResolvedValueOnce({ id: 'fileId' });
+			const testFile = new File([], 'file.pdf', { type: applicationPdf });
+			const { signal } = new AbortController();
+			await addRoomAttachment(roomId, testFile, { area: '0x0' }, signal);
+			expect(dispatchSpy).toHaveBeenCalledWith(
+				expect.objectContaining({ type: QUOTA_CHANGED_EVENT })
+			);
+			dispatchSpy.mockRestore();
+		});
+
+		test('does not dispatch event on upload failure', async () => {
+			const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+			const store = useStore.getState();
+			store.setAttributes(createMockAttributesList({ carbonioWscMaxAttachmentSize: '100' }));
+			mockUploadFileFetchAPI.mockRejectedValueOnce(new Error('upload failed'));
+			const testFile = new File([], 'file.pdf', { type: applicationPdf });
+			const { signal } = new AbortController();
+			await expect(addRoomAttachment(roomId, testFile, { area: '0x0' }, signal)).rejects.toThrow();
+			expect(dispatchSpy).not.toHaveBeenCalledWith(
+				expect.objectContaining({ type: QUOTA_CHANGED_EVENT })
+			);
+			dispatchSpy.mockRestore();
+		});
+	});
+
 	test('forwardMessages is called correctly', async () => {
 		vi.spyOn(xmppClient, 'requestMessageToForward').mockImplementation(() => Promise.resolve());
 
@@ -431,6 +477,54 @@ describe('Rooms API', () => {
 				originalMessageSentAt: dateToISODate(message.date)
 			}
 		]);
+	});
+
+	describe('forwardMessages dispatches quota changed event', () => {
+		test('dispatches event when forwarded messages have attachments', async () => {
+			const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+			vi.spyOn(xmppClient, 'requestMessageToForward').mockImplementation(() => Promise.resolve());
+
+			const message = createMockTextMessage({
+				attachment: { id: 'att1', name: 'file.pdf', mimeType: applicationPdf, size: 1024 }
+			});
+			const xmlMessage = buildTextMessageFromHistory({
+				roomId: message.roomId,
+				from: message.from,
+				text: message.text
+			});
+			const insideMessage = xmlMessage.getElementsByTagName('message')[0];
+			vi.spyOn(HistoryAccumulator, 'getForwardedMessage').mockImplementationOnce(
+				() => insideMessage
+			);
+
+			await forwardMessages(['roomId'], [message]);
+			expect(dispatchSpy).toHaveBeenCalledWith(
+				expect.objectContaining({ type: QUOTA_CHANGED_EVENT })
+			);
+			dispatchSpy.mockRestore();
+		});
+
+		test('does not dispatch event when forwarded messages have no attachments', async () => {
+			const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+			vi.spyOn(xmppClient, 'requestMessageToForward').mockImplementation(() => Promise.resolve());
+
+			const message = createMockTextMessage();
+			const xmlMessage = buildTextMessageFromHistory({
+				roomId: message.roomId,
+				from: message.from,
+				text: message.text
+			});
+			const insideMessage = xmlMessage.getElementsByTagName('message')[0];
+			vi.spyOn(HistoryAccumulator, 'getForwardedMessage').mockImplementationOnce(
+				() => insideMessage
+			);
+
+			await forwardMessages(['roomId'], [message]);
+			expect(dispatchSpy).not.toHaveBeenCalledWith(
+				expect.objectContaining({ type: QUOTA_CHANGED_EVENT })
+			);
+			dispatchSpy.mockRestore();
+		});
 	});
 
 	test('replacePlaceholderRoom is called correctly', async () => {

--- a/src/network/apis/RoomsApi.ts
+++ b/src/network/apis/RoomsApi.ts
@@ -7,7 +7,7 @@ import { gte } from 'semver';
 import { v4 as uuidGenerator } from 'uuid';
 
 import { createMeeting, deleteMeeting } from './MeetingsApi';
-import { CHATS_ROUTE } from '../../constants/appConstants';
+import { CHATS_ROUTE, QUOTA_CHANGED_EVENT } from '../../constants/appConstants';
 import { EventName, sendCustomEvent } from '../../hooks/useEventListener';
 import useStore from '../../store/Store';
 import { Attachment } from '../../types/network/models/attachmentTypes';
@@ -217,14 +217,20 @@ export const addRoomAttachment = (
 			//  * Remove once support for v1.6.0 is officially dropped.
 			if (session.apiVersion && gte(session.apiVersion, '1.6.1')) {
 				sendFileFetchAPI(`rooms/${roomId}/attachments`, RequestType.PUT, file, signal, optional)
-					.then((resp: { id: string }) => resolve(resp))
+					.then((resp: { id: string }) => {
+						window.dispatchEvent(new CustomEvent(QUOTA_CHANGED_EVENT));
+						resolve(resp);
+					})
 					.catch((error) => {
 						removePlaceholderMessage(roomId, uuid);
 						reject(new Error(error));
 					});
 			} else {
 				uploadFileFetchAPI(`rooms/${roomId}/attachments`, RequestType.POST, file, signal, optional)
-					.then((resp: { id: string }) => resolve(resp))
+					.then((resp: { id: string }) => {
+						window.dispatchEvent(new CustomEvent(QUOTA_CHANGED_EVENT));
+						resolve(resp);
+					})
 					.catch((error) => {
 						removePlaceholderMessage(roomId, uuid);
 						reject(new Error(error));
@@ -262,6 +268,11 @@ export const forwardMessages = (
 			roomsId.map((roomId) =>
 				fetchAPI<Response>(`rooms/${roomId}/forward`, RequestType.POST, messagesToForward)
 			)
-		);
+		).then((responses) => {
+			if (messages.some((message) => message.attachment)) {
+				window.dispatchEvent(new CustomEvent(QUOTA_CHANGED_EVENT));
+			}
+			return responses;
+		});
 	});
 };

--- a/src/network/apis/RoomsApi.ts
+++ b/src/network/apis/RoomsApi.ts
@@ -264,15 +264,23 @@ export const forwardMessages = (
 			originalMessage: listOfMessages[message.stanzaId],
 			originalMessageSentAt: dateToISODate(message.date)
 		}));
-		return Promise.all(
+		const hasAttachments = messages.some((message) => message.attachment);
+		return Promise.allSettled(
 			roomsId.map((roomId) =>
 				fetchAPI<Response>(`rooms/${roomId}/forward`, RequestType.POST, messagesToForward)
 			)
-		).then((responses) => {
-			if (messages.some((message) => message.attachment)) {
+		).then((results) => {
+			const fulfilled = results.filter(
+				(r): r is PromiseFulfilledResult<Response> => r.status === 'fulfilled'
+			);
+			if (hasAttachments && fulfilled.length > 0) {
 				window.dispatchEvent(new CustomEvent(QUOTA_CHANGED_EVENT));
 			}
-			return responses;
+			const rejected = results.find((r) => r.status === 'rejected');
+			if (rejected) {
+				throw (rejected as PromiseRejectedResult).reason;
+			}
+			return fulfilled.map((r) => r.value);
 		});
 	});
 };

--- a/src/network/apis/RoomsApi.ts
+++ b/src/network/apis/RoomsApi.ts
@@ -278,7 +278,7 @@ export const forwardMessages = (
 			}
 			const rejected = results.find((r) => r.status === 'rejected');
 			if (rejected) {
-				throw (rejected as PromiseRejectedResult).reason;
+				throw rejected.reason;
 			}
 			return fulfilled.map((r) => r.value);
 		});


### PR DESCRIPTION
## Summary

- Aggiunta costante `QUOTA_CHANGED_EVENT` in `appConstants.tsx`
- Dispatch dell'evento custom `carbonio-ws-collaboration-ui:quota-changed` dopo un upload di allegato riuscito (sia path legacy che 1.6.1+)
- Dispatch dell'evento anche nel forward di messaggi che contengono allegati
- Listener sull'evento in `initIntegrations.tsx` che richiama l'integrazione `storages-refresh-quota` (con debounce da 2s) per aggiornare la quota visualizzata in tempo reale
- Aggiunto script `deploy:local` in `package.json`
