### PR TITLE
build(release): update jenkins-lib-ui to 1.0.13

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 library(
-    identifier: 'jenkins-lib-ui@1.0.12',
+    identifier: 'jenkins-lib-ui@1.0.13',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',


### PR DESCRIPTION
## Summary

- Bumps `jenkins-lib-ui` from the current version to `1.0.13` in the Jenkinsfile

Part of IN-1095 JFrog cost optimization usage analysis and mitigation strategy.