### PR TITLE
fix: remove incoming call notification when user decline from another session

### DIFF
--- a/src/hooks/useEventListener.tsx
+++ b/src/hooks/useEventListener.tsx
@@ -59,7 +59,7 @@ export type IncomingMeetingEvent = {
 
 export type RemovedMeetingNotificationEvent = {
 	name: EventName.REMOVED_MEETING_NOTIFICATION;
-	data: MeetingJoinedEvent | MeetingStoppedEvent;
+	data: MeetingJoinedEvent | MeetingStoppedEvent | MeetingDeclinedEvent;
 };
 
 export type ParticipantClashedEvent = {

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingDeclinedEventHandler.test.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingDeclinedEventHandler.test.ts
@@ -44,4 +44,11 @@ describe('MeetingDeclinedEventHandler tests', () => {
 		meetingDeclinedEventHandler(event);
 		expect(dispatchEvent).not.toHaveBeenCalled();
 	});
+
+	test('REMOVED_MEETING_NOTIFICATION is dispatched when I declined a ONE_TO_ONE meeting from another session', () => {
+		const dispatchEvent = vi.spyOn(window, 'dispatchEvent');
+		meetingDeclinedEventHandler({ ...event, userId: 'myUserId' });
+		const call = dispatchEvent.mock.calls[0][0] as CustomEvent;
+		expect(call.type).toBe(EventName.REMOVED_MEETING_NOTIFICATION);
+	});
 });

--- a/src/network/websocket/wsMeetingEventHandlers/MeetingDeclinedEventHandler.ts
+++ b/src/network/websocket/wsMeetingEventHandlers/MeetingDeclinedEventHandler.ts
@@ -3,12 +3,26 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+import { find } from 'lodash';
+
 import { EventName, sendCustomEvent } from '../../../hooks/useEventListener';
+import useStore from '../../../store/Store';
 import { MeetingDeclinedEvent } from '../../../types/network/websocket/wsMeetingEvents';
-import { isMeetingActive } from '../eventHandlersUtilities';
+import { RoomType } from '../../../types/store/RoomTypes';
+import { isMeetingActive, isMyId } from '../eventHandlersUtilities';
 
 export const meetingDeclinedEventHandler = (event: MeetingDeclinedEvent): void => {
 	if (isMeetingActive(event.meetingId)) {
 		sendCustomEvent({ name: EventName.MEETING_DECLINED, data: event });
+	}
+
+	// Send custom event to delete an incoming meeting notification if I declined the meeting from another session
+	const meeting = find(useStore.getState().meetings, (meeting) => meeting.id === event.meetingId);
+	if (
+		meeting &&
+		useStore.getState().rooms[meeting.roomId]?.type === RoomType.ONE_TO_ONE &&
+		isMyId(event.userId)
+	) {
+		sendCustomEvent({ name: EventName.REMOVED_MEETING_NOTIFICATION, data: event });
 	}
 };


### PR DESCRIPTION
When a user declines a 1:1 meeting call from a different active session (another browser tab or device), the incoming call notification on the current session was not dismissed, leaving a stale notification on screen.

This fix extends `meetingDeclinedEventHandler` to dispatch a `REMOVED_MEETING_NOTIFICATION` event whenever the declining user is the current user and the meeting belongs to a one-to-one room.