### PR TITLE
fix(meeting): restore video/audio stream on temporary TURN server disconnection [CO-3707]

### DIFF
--- a/src/MainApp.tsx
+++ b/src/MainApp.tsx
@@ -35,6 +35,7 @@ export default function MainApp(): React.JSX.Element {
 
 	useEffect(() => {
 		setSupportedVersions([
+			'1.6.13',
 			'1.6.12',
 			'1.6.11',
 			'1.6.10',

--- a/src/network/API_VERSIONING.md
+++ b/src/network/API_VERSIONING.md
@@ -2,6 +2,17 @@
 
 This document tracks internal changes related to API versioning, renamed events, and modified files.
 
+## Version 1.6.13
+
+### Changes
+
+- **API**: New `PUT /meetings/${meetingId}/screen/iceRestart` endpoint to trigger an ICE restart on screenshare connections after a TURN server interruption
+
+### Affected Files
+- 'src/network/webRTC/VideoScreenInConnection.ts'
+
+---
+
 ## Version 1.6.12
 
 ### Changes
@@ -59,6 +70,19 @@ This document tracks internal changes related to API versioning, renamed events,
 ### Affected Files
 
 - 'src/meetings/components/sidebar/MeetingConversationAccordion/MeetingConversationAccordion.tsx'
+
+---
+
+## Version 1.6.6
+
+### Changes
+
+- **API**: New `PUT /meetings/${meetingId}/audio/iceRestart` and `PUT /meetings/${meetingId}/video/iceRestart` endpoints to trigger an ICE restart on audio and video connections after a TURN server interruption
+
+### Affected Files
+- 'src/network/webRTC/BidirectionalConnectionAudioInOut.ts'
+- 'src/network/webRTC/VideoOutConnection.ts'
+- 'src/network/webRTC/VideoScreenInConnection.ts'
 
 ---
 

--- a/src/network/apis/MeetingsApi.ts
+++ b/src/network/apis/MeetingsApi.ts
@@ -284,17 +284,13 @@ export const getLoginConfig = (): Promise<LoginV3ConfigResponse> =>
 		.then((resp) => resp.json())
 		.catch((err: Error) => console.error(err));
 
-export const audioIceRestart = (meetingId: string, sdpOffer: string): Promise<Response> =>
-	fetchAPI(`meetings/${meetingId}/audio/iceRestart`, RequestType.PUT, {
-		sdp: sdpOffer
-	});
+export const audioIceRestart = (meetingId: string, sdp: string): Promise<Response> =>
+	fetchAPI(`meetings/${meetingId}/audio/iceRestart`, RequestType.PUT, { sdp });
 
 export const videoIceRestart = (meetingId: string, sdp?: string): Promise<Response> => {
 	const body = { ...(sdp && { sdp }) };
 	return fetchAPI(`meetings/${meetingId}/video/iceRestart`, RequestType.PUT, body);
 };
 
-export const screenIceRestart = (meetingId: string, sdp?: string): Promise<Response> => {
-	const body = { ...(sdp && { sdp }) };
-	return fetchAPI(`meetings/${meetingId}/screen/iceRestart`, RequestType.PUT, body);
-};
+export const screenIceRestart = (meetingId: string, sdp: string): Promise<Response> =>
+	fetchAPI(`meetings/${meetingId}/screen/iceRestart`, RequestType.PUT, { sdp });

--- a/src/network/apis/MeetingsApi.ts
+++ b/src/network/apis/MeetingsApi.ts
@@ -284,12 +284,17 @@ export const getLoginConfig = (): Promise<LoginV3ConfigResponse> =>
 		.then((resp) => resp.json())
 		.catch((err: Error) => console.error(err));
 
-export const sendConfigureWithOffer = (meetingId: string, sdpOffer: string): Promise<Response> =>
+export const audioIceRestart = (meetingId: string, sdpOffer: string): Promise<Response> =>
 	fetchAPI(`meetings/${meetingId}/audio/iceRestart`, RequestType.PUT, {
 		sdp: sdpOffer
 	});
 
-export const iceRestartIncoming = (meetingId: string, sdp?: string): Promise<Response> => {
+export const videoIceRestart = (meetingId: string, sdp?: string): Promise<Response> => {
 	const body = { ...(sdp && { sdp }) };
 	return fetchAPI(`meetings/${meetingId}/video/iceRestart`, RequestType.PUT, body);
+};
+
+export const screenIceRestart = (meetingId: string, sdp?: string): Promise<Response> => {
+	const body = { ...(sdp && { sdp }) };
+	return fetchAPI(`meetings/${meetingId}/screen/iceRestart`, RequestType.PUT, body);
 };

--- a/src/network/apis/MeetingsApi.ts
+++ b/src/network/apis/MeetingsApi.ts
@@ -284,6 +284,11 @@ export const getLoginConfig = (): Promise<LoginV3ConfigResponse> =>
 		.then((resp) => resp.json())
 		.catch((err: Error) => console.error(err));
 
+export const sendConfigureWithOffer = (meetingId: string, sdpOffer: string): Promise<Response> =>
+	fetchAPI(`meetings/${meetingId}/audio/iceRestart`, RequestType.PUT, {
+		sdp: sdpOffer
+	});
+
 export const iceRestartIncoming = (meetingId: string, sdp?: string): Promise<Response> => {
 	const body = { ...(sdp && { sdp }) };
 	return fetchAPI(`meetings/${meetingId}/video/iceRestart`, RequestType.PUT, body);

--- a/src/network/apis/MeetingsApi.ts
+++ b/src/network/apis/MeetingsApi.ts
@@ -283,3 +283,8 @@ export const getLoginConfig = (): Promise<LoginV3ConfigResponse> =>
 		})
 		.then((resp) => resp.json())
 		.catch((err: Error) => console.error(err));
+
+export const iceRestartIncoming = (meetingId: string, sdp?: string): Promise<Response> => {
+	const body = { ...(sdp && { sdp }) };
+	return fetchAPI(`meetings/${meetingId}/video/iceRestart`, RequestType.PUT, body);
+};

--- a/src/network/webRTC/BidirectionalConnectionAudioInOut.ts
+++ b/src/network/webRTC/BidirectionalConnectionAudioInOut.ts
@@ -5,17 +5,14 @@
  */
 
 import { first } from 'lodash';
+import { gte } from 'semver';
 
 import { PeerConnConfig } from './PeerConnConfig';
 import useStore from '../../store/Store';
 import { IBidirectionalConnectionAudioInOut } from '../../types/network/webRTC/webRTC';
 import { STREAM_TYPE } from '../../types/store/ActiveMeetingTypes';
 import { getAudioStream } from '../../utils/UserMediaManager';
-import {
-	createAudioOffer,
-	sendConfigureWithOffer,
-	updateAudioStreamStatus
-} from '../apis/MeetingsApi';
+import { audioIceRestart, createAudioOffer, updateAudioStreamStatus } from '../apis/MeetingsApi';
 
 export default class BidirectionalConnectionAudioInOut implements IBidirectionalConnectionAudioInOut {
 	peerConn: RTCPeerConnection;
@@ -100,8 +97,9 @@ export default class BidirectionalConnectionAudioInOut implements IBidirectional
 						?.setLocalDescription(rtcSessionDesc)
 						.then(() => {
 							const localDesc = this.peerConn?.localDescription;
-							if (localDesc?.sdp) {
-								sendConfigureWithOffer(this.meetingId, localDesc.sdp);
+							const version = useStore.getState().session.apiVersion;
+							if (localDesc?.sdp && version && gte(version, '1.6.6')) {
+								audioIceRestart(this.meetingId, localDesc.sdp);
 							}
 						})
 						.catch((reason) => console.warn('setLocalDescription failed', reason));
@@ -115,22 +113,6 @@ export default class BidirectionalConnectionAudioInOut implements IBidirectional
 		if (this.peerConn.signalingState !== 'have-remote-offer') {
 			const remoteDescription: RTCSessionDescription = new RTCSessionDescription(remoteAnswer);
 			this.peerConn.setRemoteDescription(remoteDescription);
-		}
-	}
-
-	// TODO check its usage
-	handleOfferCreated(rtcSessDesc: RTCSessionDescriptionInit): void {
-		if (this.peerConn.signalingState === 'stable' && this.peerConn.localDescription == null) {
-			this.peerConn
-				.setLocalDescription(rtcSessDesc)
-				.then(() => {
-					if (rtcSessDesc.sdp) {
-						createAudioOffer(this.meetingId, rtcSessDesc.sdp).then(() => {
-							updateAudioStreamStatus(this.meetingId, this.initialAudioStatus);
-						});
-					}
-				})
-				.catch((reason) => console.warn(reason));
 		}
 	}
 

--- a/src/network/webRTC/BidirectionalConnectionAudioInOut.ts
+++ b/src/network/webRTC/BidirectionalConnectionAudioInOut.ts
@@ -86,9 +86,8 @@ export default class BidirectionalConnectionAudioInOut implements IBidirectional
 			.catch((reason) => console.warn('createOffer failed', reason));
 	};
 
-	onConnectionStateChange = (): void => {
+	private readonly onConnectionStateChange = (): void => {
 		const state = this.peerConn?.connectionState;
-		console.log('AUDIO IN/OUT onConnectionStateChange:', state);
 		if (state === 'failed') {
 			this.peerConn
 				?.createOffer({ iceRestart: true })

--- a/src/network/webRTC/BidirectionalConnectionAudioInOut.ts
+++ b/src/network/webRTC/BidirectionalConnectionAudioInOut.ts
@@ -11,11 +11,13 @@ import useStore from '../../store/Store';
 import { IBidirectionalConnectionAudioInOut } from '../../types/network/webRTC/webRTC';
 import { STREAM_TYPE } from '../../types/store/ActiveMeetingTypes';
 import { getAudioStream } from '../../utils/UserMediaManager';
-import { createAudioOffer, updateAudioStreamStatus } from '../apis/MeetingsApi';
+import {
+	createAudioOffer,
+	sendConfigureWithOffer,
+	updateAudioStreamStatus
+} from '../apis/MeetingsApi';
 
-export default class BidirectionalConnectionAudioInOut
-	// eslint-disable-next-line prettier/prettier
-	implements IBidirectionalConnectionAudioInOut {
+export default class BidirectionalConnectionAudioInOut implements IBidirectionalConnectionAudioInOut {
 	peerConn: RTCPeerConnection;
 
 	meetingId: string;
@@ -32,7 +34,7 @@ export default class BidirectionalConnectionAudioInOut
 		this.peerConn = new RTCPeerConnection(new PeerConnConfig().getConfig());
 		this.peerConn.ontrack = this.onTrack;
 		this.peerConn.onnegotiationneeded = this.onNegotiationNeeded;
-		this.peerConn.oniceconnectionstatechange = this.onIceConnectionStateChange;
+		this.peerConn.onconnectionstatechange = this.onConnectionStateChange;
 
 		this.meetingId = meetingId;
 		this.rtpSender = null;
@@ -87,11 +89,24 @@ export default class BidirectionalConnectionAudioInOut
 			.catch((reason) => console.warn('createOffer failed', reason));
 	};
 
-	onIceConnectionStateChange = (ev: Event): void => {
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-ignore
-		if (ev.target.iceConnectionState === 'failed') {
-			this.onNegotiationNeeded();
+	onConnectionStateChange = (): void => {
+		const state = this.peerConn?.connectionState;
+		console.log('AUDIO IN/OUT onConnectionStateChange:', state);
+		if (state === 'failed') {
+			this.peerConn
+				?.createOffer({ iceRestart: true })
+				.then((rtcSessionDesc) => {
+					this.peerConn
+						?.setLocalDescription(rtcSessionDesc)
+						.then(() => {
+							const localDesc = this.peerConn?.localDescription;
+							if (localDesc?.sdp) {
+								sendConfigureWithOffer(this.meetingId, localDesc.sdp);
+							}
+						})
+						.catch((reason) => console.warn('setLocalDescription failed', reason));
+				})
+				.catch((reason) => console.warn('createOffer with iceRestart failed', reason));
 		}
 	};
 

--- a/src/network/webRTC/ScreenOutConnection.ts
+++ b/src/network/webRTC/ScreenOutConnection.ts
@@ -9,7 +9,7 @@ import useStore from '../../store/Store';
 import { IScreenOutConnection } from '../../types/network/webRTC/webRTC';
 import { STREAM_TYPE } from '../../types/store/ActiveMeetingTypes';
 import { getScreenStream } from '../../utils/UserMediaManager';
-import { updateMediaOffer } from '../apis/MeetingsApi';
+import { iceRestartIncoming, updateMediaOffer } from '../apis/MeetingsApi';
 
 export default class ScreenOutConnection implements IScreenOutConnection {
 	peerConn: RTCPeerConnection | null;
@@ -25,7 +25,7 @@ export default class ScreenOutConnection implements IScreenOutConnection {
 	}
 
 	// Create SDP offer, set it as local description and send it to the remote peer
-	private onNegotiationNeeded = (): void => {
+	private readonly onNegotiationNeeded = (): void => {
 		this.peerConn
 			?.createOffer()
 			.then((rtcSessionDesc: RTCSessionDescriptionInit) => {
@@ -39,14 +39,6 @@ export default class ScreenOutConnection implements IScreenOutConnection {
 				}
 			})
 			.catch((reason) => console.warn('createOffer failed', reason));
-	};
-
-	private onIceConnectionStateChange = (ev: Event): void => {
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-ignore
-		if (ev.target.iceConnectionState === 'failed') {
-			this.onNegotiationNeeded();
-		}
 	};
 
 	private updateLocalStreamTrack(mediaStreamTrack: MediaStream): Promise<MediaStreamTrack> {
@@ -71,13 +63,34 @@ export default class ScreenOutConnection implements IScreenOutConnection {
 	public startScreenShare(): void {
 		this.peerConn = new RTCPeerConnection(new PeerConnConfig().getConfig());
 		this.peerConn.onnegotiationneeded = this.onNegotiationNeeded;
-		this.peerConn.oniceconnectionstatechange = this.onIceConnectionStateChange;
+		this.peerConn.onconnectionstatechange = this.onConnectionStateChange;
 
 		getScreenStream().then((stream) => {
 			this.updateLocalStreamTrack(stream);
 			useStore.getState().setLocalStreams(STREAM_TYPE.SCREEN, stream);
 		});
 	}
+
+	private readonly onConnectionStateChange = (): void => {
+		const state = this.peerConn?.connectionState;
+		console.log('SCREEN OUT onConnectionStateChange:', state);
+		if (state === 'failed') {
+			this.peerConn
+				?.createOffer({ iceRestart: true })
+				.then((rtcSessionDesc) => {
+					this.peerConn
+						?.setLocalDescription(rtcSessionDesc)
+						.then(() => {
+							const localDesc = this.peerConn?.localDescription;
+							if (localDesc?.sdp) {
+								iceRestartIncoming(this.meetingId, localDesc.sdp);
+							}
+						})
+						.catch((reason) => console.warn('setLocalDescription failed', reason));
+				})
+				.catch((reason) => console.warn('createOffer with iceRestart failed', reason));
+		}
+	};
 
 	// Handle remote answer to the SDP offer arrived from the signaling channel
 	public handleRemoteAnswer(remoteAnswer: RTCSessionDescriptionInit): void {

--- a/src/network/webRTC/ScreenOutConnection.ts
+++ b/src/network/webRTC/ScreenOutConnection.ts
@@ -75,7 +75,6 @@ export default class ScreenOutConnection implements IScreenOutConnection {
 
 	private readonly onConnectionStateChange = (): void => {
 		const state = this.peerConn?.connectionState;
-		console.log('SCREEN OUT onConnectionStateChange:', state);
 		if (state === 'failed') {
 			this.peerConn
 				?.createOffer({ iceRestart: true })

--- a/src/network/webRTC/ScreenOutConnection.ts
+++ b/src/network/webRTC/ScreenOutConnection.ts
@@ -4,12 +4,14 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import { gte } from 'semver';
+
 import { PeerConnConfig } from './PeerConnConfig';
 import useStore from '../../store/Store';
 import { IScreenOutConnection } from '../../types/network/webRTC/webRTC';
 import { STREAM_TYPE } from '../../types/store/ActiveMeetingTypes';
 import { getScreenStream } from '../../utils/UserMediaManager';
-import { iceRestartIncoming, updateMediaOffer } from '../apis/MeetingsApi';
+import { updateMediaOffer, screenIceRestart } from '../apis/MeetingsApi';
 
 export default class ScreenOutConnection implements IScreenOutConnection {
 	peerConn: RTCPeerConnection | null;
@@ -82,8 +84,9 @@ export default class ScreenOutConnection implements IScreenOutConnection {
 						?.setLocalDescription(rtcSessionDesc)
 						.then(() => {
 							const localDesc = this.peerConn?.localDescription;
-							if (localDesc?.sdp) {
-								iceRestartIncoming(this.meetingId, localDesc.sdp);
+							const version = useStore.getState().session.apiVersion;
+							if (localDesc?.sdp && version && gte(version, '1.6.13')) {
+								screenIceRestart(this.meetingId, localDesc.sdp);
 							}
 						})
 						.catch((reason) => console.warn('setLocalDescription failed', reason));

--- a/src/network/webRTC/VideoOutConnection.ts
+++ b/src/network/webRTC/VideoOutConnection.ts
@@ -20,8 +20,6 @@ export default class VideoOutConnection implements IVideoOutConnection {
 
 	selectedVideoDeviceId: string | undefined;
 
-	private iceRestartInterval: ReturnType<typeof setInterval> | null = null;
-
 	constructor(meetingId: string, videoStreamEnabled: boolean, selectedVideoDeviceId?: string) {
 		this.peerConn = null;
 		this.meetingId = meetingId;
@@ -72,7 +70,7 @@ export default class VideoOutConnection implements IVideoOutConnection {
 			.catch((reason) => console.warn('createOffer failed', reason));
 	};
 
-	private onConnectionStateChange = (): void => {
+	private readonly onConnectionStateChange = (): void => {
 		const state = this.peerConn?.connectionState;
 		console.log('VIDEO OUT onConnectionStateChange:', state);
 		if (state === 'failed') {
@@ -126,10 +124,6 @@ export default class VideoOutConnection implements IVideoOutConnection {
 	}
 
 	public closePeerConnection(): void {
-		if (this.iceRestartInterval !== null) {
-			clearInterval(this.iceRestartInterval);
-			this.iceRestartInterval = null;
-		}
 		useStore.getState().removeLocalStreams(STREAM_TYPE.VIDEO);
 		useStore.getState().removeBackgroundStream();
 		this.rtpSender?.track?.stop();

--- a/src/network/webRTC/VideoOutConnection.ts
+++ b/src/network/webRTC/VideoOutConnection.ts
@@ -9,7 +9,7 @@ import useStore from '../../store/Store';
 import { IVideoOutConnection } from '../../types/network/webRTC/webRTC';
 import { STREAM_TYPE } from '../../types/store/ActiveMeetingTypes';
 import { getVideoStream } from '../../utils/UserMediaManager';
-import { updateMediaOffer } from '../apis/MeetingsApi';
+import { iceRestartIncoming, updateMediaOffer } from '../apis/MeetingsApi';
 
 export default class VideoOutConnection implements IVideoOutConnection {
 	peerConn: RTCPeerConnection | null;
@@ -36,7 +36,6 @@ export default class VideoOutConnection implements IVideoOutConnection {
 		return new Promise((resolve, reject) => {
 			this.peerConn = new RTCPeerConnection(new PeerConnConfig().getConfig());
 			this.peerConn.onnegotiationneeded = this.onNegotiationNeeded;
-			this.peerConn.oniceconnectionstatechange = this.onIceConnectionStateChange;
 			this.peerConn.onconnectionstatechange = this.onConnectionStateChange;
 
 			if (selectedVideoDeviceId) this.selectedVideoDeviceId = selectedVideoDeviceId;
@@ -73,51 +72,24 @@ export default class VideoOutConnection implements IVideoOutConnection {
 			.catch((reason) => console.warn('createOffer failed', reason));
 	};
 
-	private onIceConnectionStateChange = (): void => {
-		console.log('onIceConnectionStateChange:', this.peerConn?.iceConnectionState);
-	};
-
 	private onConnectionStateChange = (): void => {
 		const state = this.peerConn?.connectionState;
-		console.log('onConnectionStateChange:', state);
-
-		if (state === 'disconnected') {
-			this.iceRestartInterval = setInterval(() => {
-				console.log('ICE restart attempt (disconnected)');
-				this.peerConn?.restartIce();
-			}, 2000);
-		}
-
-		if (state === 'connected') {
-			if (this.iceRestartInterval !== null) {
-				clearInterval(this.iceRestartInterval);
-				this.iceRestartInterval = null;
-			}
-		}
-
+		console.log('VIDEO OUT onConnectionStateChange:', state);
 		if (state === 'failed') {
-			if (this.iceRestartInterval !== null) {
-				clearInterval(this.iceRestartInterval);
-				this.iceRestartInterval = null;
-			}
 			this.peerConn
 				?.createOffer({ iceRestart: true })
 				.then((rtcSessionDesc) => {
 					this.peerConn
 						?.setLocalDescription(rtcSessionDesc)
 						.then(() => {
-							updateMediaOffer(this.meetingId, STREAM_TYPE.VIDEO, true, rtcSessionDesc.sdp);
+							const localDesc = this.peerConn?.localDescription;
+							if (localDesc?.sdp) {
+								iceRestartIncoming(this.meetingId, localDesc.sdp);
+							}
 						})
 						.catch((reason) => console.warn('setLocalDescription failed', reason));
 				})
 				.catch((reason) => console.warn('createOffer with iceRestart failed', reason));
-		}
-
-		if (state === 'closed') {
-			if (this.iceRestartInterval !== null) {
-				clearInterval(this.iceRestartInterval);
-				this.iceRestartInterval = null;
-			}
 		}
 	};
 

--- a/src/network/webRTC/VideoOutConnection.ts
+++ b/src/network/webRTC/VideoOutConnection.ts
@@ -74,7 +74,6 @@ export default class VideoOutConnection implements IVideoOutConnection {
 
 	private readonly onConnectionStateChange = (): void => {
 		const state = this.peerConn?.connectionState;
-		console.log('VIDEO OUT onConnectionStateChange:', state);
 		if (state === 'failed') {
 			this.peerConn
 				?.createOffer({ iceRestart: true })

--- a/src/network/webRTC/VideoOutConnection.ts
+++ b/src/network/webRTC/VideoOutConnection.ts
@@ -20,6 +20,8 @@ export default class VideoOutConnection implements IVideoOutConnection {
 
 	selectedVideoDeviceId: string | undefined;
 
+	private iceRestartTimeout: ReturnType<typeof setTimeout> | null = null;
+
 	constructor(meetingId: string, videoStreamEnabled: boolean, selectedVideoDeviceId?: string) {
 		this.peerConn = null;
 		this.meetingId = meetingId;
@@ -35,6 +37,7 @@ export default class VideoOutConnection implements IVideoOutConnection {
 			this.peerConn = new RTCPeerConnection(new PeerConnConfig().getConfig());
 			this.peerConn.onnegotiationneeded = this.onNegotiationNeeded;
 			this.peerConn.oniceconnectionstatechange = this.onIceConnectionStateChange;
+			this.peerConn.onconnectionstatechange = this.onStateChange;
 
 			if (selectedVideoDeviceId) this.selectedVideoDeviceId = selectedVideoDeviceId;
 
@@ -70,11 +73,52 @@ export default class VideoOutConnection implements IVideoOutConnection {
 			.catch((reason) => console.warn('createOffer failed', reason));
 	};
 
-	private onIceConnectionStateChange = (ev: Event): void => {
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-ignore
-		if (ev.target.iceConnectionState === 'failed') {
+	private onIceConnectionStateChange = (): void => {
+		const state = this.peerConn?.iceConnectionState;
+		console.log(state);
+		if (state === 'disconnected') {
+			// Give the browser time to self-recover before forcing a restart
+			this.iceRestartTimeout = setTimeout(() => {
+				console.log('ice restarting');
+				this.peerConn?.restartIce();
+			}, 5000);
+		}
+
+		if (state === 'connected' || state === 'completed') {
+			if (this.iceRestartTimeout !== null) {
+				clearTimeout(this.iceRestartTimeout);
+				this.iceRestartTimeout = null;
+			}
+		}
+
+		if (state === 'failed') {
+			if (this.iceRestartTimeout !== null) {
+				clearTimeout(this.iceRestartTimeout);
+				this.iceRestartTimeout = null;
+			}
 			this.onNegotiationNeeded();
+		}
+	};
+
+	private onStateChange = (ev): void => {
+		const state = ev.target.connectionState;
+		if (state === 'failed') {
+			console.log('FAILEDDDDDDDD');
+			if (this.iceRestartTimeout !== null) {
+				clearTimeout(this.iceRestartTimeout);
+				this.iceRestartTimeout = null;
+			}
+			this.iceRestartTimeout = setTimeout(() => {
+				console.log('ice restarting');
+				this.peerConn?.restartIce();
+			}, 5000);
+		}
+		if (state === 'closed') {
+			console.log('CLOSEDDDDDD');
+			if (this.iceRestartTimeout !== null) {
+				clearTimeout(this.iceRestartTimeout);
+				this.iceRestartTimeout = null;
+			}
 		}
 	};
 
@@ -111,6 +155,10 @@ export default class VideoOutConnection implements IVideoOutConnection {
 	}
 
 	public closePeerConnection(): void {
+		if (this.iceRestartTimeout !== null) {
+			clearTimeout(this.iceRestartTimeout);
+			this.iceRestartTimeout = null;
+		}
 		useStore.getState().removeLocalStreams(STREAM_TYPE.VIDEO);
 		useStore.getState().removeBackgroundStream();
 		this.rtpSender?.track?.stop();

--- a/src/network/webRTC/VideoOutConnection.ts
+++ b/src/network/webRTC/VideoOutConnection.ts
@@ -20,7 +20,7 @@ export default class VideoOutConnection implements IVideoOutConnection {
 
 	selectedVideoDeviceId: string | undefined;
 
-	private iceRestartTimeout: ReturnType<typeof setTimeout> | null = null;
+	private iceRestartInterval: ReturnType<typeof setInterval> | null = null;
 
 	constructor(meetingId: string, videoStreamEnabled: boolean, selectedVideoDeviceId?: string) {
 		this.peerConn = null;
@@ -37,7 +37,7 @@ export default class VideoOutConnection implements IVideoOutConnection {
 			this.peerConn = new RTCPeerConnection(new PeerConnConfig().getConfig());
 			this.peerConn.onnegotiationneeded = this.onNegotiationNeeded;
 			this.peerConn.oniceconnectionstatechange = this.onIceConnectionStateChange;
-			this.peerConn.onconnectionstatechange = this.onStateChange;
+			this.peerConn.onconnectionstatechange = this.onConnectionStateChange;
 
 			if (selectedVideoDeviceId) this.selectedVideoDeviceId = selectedVideoDeviceId;
 
@@ -74,50 +74,49 @@ export default class VideoOutConnection implements IVideoOutConnection {
 	};
 
 	private onIceConnectionStateChange = (): void => {
-		const state = this.peerConn?.iceConnectionState;
-		console.log(state);
-		if (state === 'disconnected') {
-			// Give the browser time to self-recover before forcing a restart
-			this.iceRestartTimeout = setTimeout(() => {
-				console.log('ice restarting');
-				this.peerConn?.restartIce();
-			}, 5000);
-		}
-
-		if (state === 'connected' || state === 'completed') {
-			if (this.iceRestartTimeout !== null) {
-				clearTimeout(this.iceRestartTimeout);
-				this.iceRestartTimeout = null;
-			}
-		}
-
-		if (state === 'failed') {
-			if (this.iceRestartTimeout !== null) {
-				clearTimeout(this.iceRestartTimeout);
-				this.iceRestartTimeout = null;
-			}
-			this.onNegotiationNeeded();
-		}
+		console.log('onIceConnectionStateChange:', this.peerConn?.iceConnectionState);
 	};
 
-	private onStateChange = (ev): void => {
-		const state = ev.target.connectionState;
-		if (state === 'failed') {
-			console.log('FAILEDDDDDDDD');
-			if (this.iceRestartTimeout !== null) {
-				clearTimeout(this.iceRestartTimeout);
-				this.iceRestartTimeout = null;
-			}
-			this.iceRestartTimeout = setTimeout(() => {
-				console.log('ice restarting');
+	private onConnectionStateChange = (): void => {
+		const state = this.peerConn?.connectionState;
+		console.log('onConnectionStateChange:', state);
+
+		if (state === 'disconnected') {
+			this.iceRestartInterval = setInterval(() => {
+				console.log('ICE restart attempt (disconnected)');
 				this.peerConn?.restartIce();
-			}, 5000);
+			}, 2000);
 		}
+
+		if (state === 'connected') {
+			if (this.iceRestartInterval !== null) {
+				clearInterval(this.iceRestartInterval);
+				this.iceRestartInterval = null;
+			}
+		}
+
+		if (state === 'failed') {
+			if (this.iceRestartInterval !== null) {
+				clearInterval(this.iceRestartInterval);
+				this.iceRestartInterval = null;
+			}
+			this.peerConn
+				?.createOffer({ iceRestart: true })
+				.then((rtcSessionDesc) => {
+					this.peerConn
+						?.setLocalDescription(rtcSessionDesc)
+						.then(() => {
+							updateMediaOffer(this.meetingId, STREAM_TYPE.VIDEO, true, rtcSessionDesc.sdp);
+						})
+						.catch((reason) => console.warn('setLocalDescription failed', reason));
+				})
+				.catch((reason) => console.warn('createOffer with iceRestart failed', reason));
+		}
+
 		if (state === 'closed') {
-			console.log('CLOSEDDDDDD');
-			if (this.iceRestartTimeout !== null) {
-				clearTimeout(this.iceRestartTimeout);
-				this.iceRestartTimeout = null;
+			if (this.iceRestartInterval !== null) {
+				clearInterval(this.iceRestartInterval);
+				this.iceRestartInterval = null;
 			}
 		}
 	};
@@ -155,9 +154,9 @@ export default class VideoOutConnection implements IVideoOutConnection {
 	}
 
 	public closePeerConnection(): void {
-		if (this.iceRestartTimeout !== null) {
-			clearTimeout(this.iceRestartTimeout);
-			this.iceRestartTimeout = null;
+		if (this.iceRestartInterval !== null) {
+			clearInterval(this.iceRestartInterval);
+			this.iceRestartInterval = null;
 		}
 		useStore.getState().removeLocalStreams(STREAM_TYPE.VIDEO);
 		useStore.getState().removeBackgroundStream();

--- a/src/network/webRTC/VideoOutConnection.ts
+++ b/src/network/webRTC/VideoOutConnection.ts
@@ -4,12 +4,14 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import { gte } from 'semver';
+
 import { PeerConnConfig } from './PeerConnConfig';
 import useStore from '../../store/Store';
 import { IVideoOutConnection } from '../../types/network/webRTC/webRTC';
 import { STREAM_TYPE } from '../../types/store/ActiveMeetingTypes';
 import { getVideoStream } from '../../utils/UserMediaManager';
-import { iceRestartIncoming, updateMediaOffer } from '../apis/MeetingsApi';
+import { videoIceRestart, updateMediaOffer } from '../apis/MeetingsApi';
 
 export default class VideoOutConnection implements IVideoOutConnection {
 	peerConn: RTCPeerConnection | null;
@@ -81,8 +83,9 @@ export default class VideoOutConnection implements IVideoOutConnection {
 						?.setLocalDescription(rtcSessionDesc)
 						.then(() => {
 							const localDesc = this.peerConn?.localDescription;
-							if (localDesc?.sdp) {
-								iceRestartIncoming(this.meetingId, localDesc.sdp);
+							const version = useStore.getState().session.apiVersion;
+							if (localDesc?.sdp && version && gte(version, '1.6.6')) {
+								videoIceRestart(this.meetingId, localDesc.sdp);
 							}
 						})
 						.catch((reason) => console.warn('setLocalDescription failed', reason));

--- a/src/network/webRTC/VideoScreenInConnection.ts
+++ b/src/network/webRTC/VideoScreenInConnection.ts
@@ -12,7 +12,7 @@ import useStore from '../../store/Store';
 import { StreamInfo, StreamMap } from '../../types/network/models/meetingBeTypes';
 import { IVideoScreenInConnection } from '../../types/network/webRTC/webRTC';
 import { STREAM_TYPE, StreamsSubscriptionMap } from '../../types/store/ActiveMeetingTypes';
-import { createMediaAnswer } from '../apis/MeetingsApi';
+import { createMediaAnswer, iceRestartIncoming } from '../apis/MeetingsApi';
 
 export default class VideoScreenInConnection implements IVideoScreenInConnection {
 	peerConn: RTCPeerConnection;
@@ -26,10 +26,19 @@ export default class VideoScreenInConnection implements IVideoScreenInConnection
 	constructor(meetingId: string) {
 		this.peerConn = new RTCPeerConnection(new PeerConnConfig().getConfig());
 		this.peerConn.ontrack = this.onTrack;
+		this.peerConn.onconnectionstatechange = this.onConnectionStateChange;
 		this.meetingId = meetingId;
 		this.subscriptionManager = new SubscriptionsManager(meetingId);
 		this.streamsMap = {};
 	}
+
+	private onConnectionStateChange = (): void => {
+		const state = this.peerConn?.connectionState;
+		console.log('VIDEOIN onConnectionStateChange:', state);
+		if (state === 'failed') {
+			iceRestartIncoming(this.meetingId);
+		}
+	};
 
 	// Handle remote offer creating an answer and sending it to the remote peer
 	public handleRemoteOffer(sdp: string): void {

--- a/src/network/webRTC/VideoScreenInConnection.ts
+++ b/src/network/webRTC/VideoScreenInConnection.ts
@@ -35,7 +35,6 @@ export default class VideoScreenInConnection implements IVideoScreenInConnection
 
 	private readonly onConnectionStateChange = (): void => {
 		const state = this.peerConn?.connectionState;
-		console.log('VIDEOIN onConnectionStateChange:', state);
 		const version = useStore.getState().session.apiVersion;
 		if (state === 'failed' && version && gte(version, '1.6.6')) {
 			videoIceRestart(this.meetingId);

--- a/src/network/webRTC/VideoScreenInConnection.ts
+++ b/src/network/webRTC/VideoScreenInConnection.ts
@@ -5,6 +5,7 @@
  */
 
 import { filter, forEach, keyBy } from 'lodash';
+import { gte } from 'semver';
 
 import { PeerConnConfig } from './PeerConnConfig';
 import SubscriptionsManager from './SubscriptionsManager';
@@ -12,7 +13,7 @@ import useStore from '../../store/Store';
 import { StreamInfo, StreamMap } from '../../types/network/models/meetingBeTypes';
 import { IVideoScreenInConnection } from '../../types/network/webRTC/webRTC';
 import { STREAM_TYPE, StreamsSubscriptionMap } from '../../types/store/ActiveMeetingTypes';
-import { createMediaAnswer, iceRestartIncoming } from '../apis/MeetingsApi';
+import { createMediaAnswer, videoIceRestart } from '../apis/MeetingsApi';
 
 export default class VideoScreenInConnection implements IVideoScreenInConnection {
 	peerConn: RTCPeerConnection;
@@ -35,8 +36,9 @@ export default class VideoScreenInConnection implements IVideoScreenInConnection
 	private readonly onConnectionStateChange = (): void => {
 		const state = this.peerConn?.connectionState;
 		console.log('VIDEOIN onConnectionStateChange:', state);
-		if (state === 'failed') {
-			iceRestartIncoming(this.meetingId);
+		const version = useStore.getState().session.apiVersion;
+		if (state === 'failed' && version && gte(version, '1.6.6')) {
+			videoIceRestart(this.meetingId);
 		}
 	};
 

--- a/src/network/webRTC/VideoScreenInConnection.ts
+++ b/src/network/webRTC/VideoScreenInConnection.ts
@@ -32,7 +32,7 @@ export default class VideoScreenInConnection implements IVideoScreenInConnection
 		this.streamsMap = {};
 	}
 
-	private onConnectionStateChange = (): void => {
+	private readonly onConnectionStateChange = (): void => {
 		const state = this.peerConn?.connectionState;
 		console.log('VIDEOIN onConnectionStateChange:', state);
 		if (state === 'failed') {

--- a/src/types/network/webRTC/webRTC.ts
+++ b/src/types/network/webRTC/webRTC.ts
@@ -26,7 +26,6 @@ export interface IBidirectionalConnectionAudioInOut extends IPeerConnection {
 	oscillatorAudioTrack: MediaStreamTrack | undefined;
 	onTrack: (trackEvent: RTCTrackEvent) => void;
 	onNegotiationNeeded: () => void;
-	onIceConnectionStateChange: (ev: Event) => void;
 	handleRemoteAnswer(remoteAnswer: RTCSessionDescriptionInit): void;
 	updateLocalStreamTrack(mediaStreamTrack: MediaStream): Promise<MediaStreamTrack>;
 	updateRemoteStreamAudio(): void;


### PR DESCRIPTION
Audio, video and screenshare streams were not recovering after a temporary TURN server interruption. The previous handler watched `iceConnectionState`, which never transitions to `failed` in this scenario, only `connectionState` does.

Peer connections now listen to `onconnectionstatechange`: on `failed`, the outgoing connection triggers an explicit `createOffer({ iceRestart: true })`.
