### PR TITLE
fix: add PreviewNavigationManager to meeting initialization to suppor…

### DIFF
--- a/src/meetings/initMeetings.tsx
+++ b/src/meetings/initMeetings.tsx
@@ -11,6 +11,7 @@ import { addRoute } from '@zextras/carbonio-shell-ui';
 
 import ShimmerEntryMeetingView from './views/shimmers/ShimmerEntryMeetingView';
 import ConnectionSnackbarManager from '../chats/components/ConnectionSnackbarManager';
+import PreviewNavigationManager from '../chats/components/PreviewNavigationManager';
 import { MEETINGS_NAME, MEETINGS_ROUTE } from '../constants/appConstants';
 
 const LazyMeetingMainView = lazy(
@@ -21,6 +22,7 @@ const MeetingMain = (): React.JSX.Element => (
 	<Suspense fallback={<ShimmerEntryMeetingView />}>
 		<ModalManager>
 			<ConnectionSnackbarManager />
+			<PreviewNavigationManager />
 			<LazyMeetingMainView />
 		</ModalManager>
 	</Suspense>


### PR DESCRIPTION
Commit `da303b5f` (*feat: navigate attachments preview*) replaced the old self-contained `usePreview` hook — which called `createPreview()` directly from `PreviewsManagerContext` — with a two-layer architecture:

1. **`usePreviewNavigation`** writes preview data to the Zustand store
2. **`PreviewNavigationManager`** reads from the store and calls `openPreview()` on the context

The `PreviewNavigationManager` component was added to `initChats.tsx` but **not** to `initMeetings.tsx`. As a result, when clicking an attachment in the meeting chat, `usePreviewNavigation().openFromChat()` correctly updates the store, but no `PreviewNavigationManager` is mounted in the meeting component tree to react to the state change and open the preview.

Refs: CO-3823