### PR TITLE
fix: recover audio/video toggle buttons after a failed call [CO-3865]

### DIFF
--- a/src/meetings/components/meetingActionsBar/CameraButton.test.tsx
+++ b/src/meetings/components/meetingActionsBar/CameraButton.test.tsx
@@ -39,6 +39,8 @@ const activeMeetingSetup = (videoStreamOn: boolean): void => {
 	store.meetingConnection(mockMeeting.id);
 };
 
+const controlledError = new Error('Controlled error');
+
 const cameraButtonComponent = (
 	<CameraButton
 		videoDropdownRef={React.createRef<HTMLDivElement>()}
@@ -125,7 +127,7 @@ describe('Camera button', () => {
 	test('Camera button is re-enabled when updateMediaOffer fails', async () => {
 		activeMeetingSetup(false);
 		vi.spyOn(UserMediaManager, 'getVideoStream').mockResolvedValue({} as MediaStream);
-		vi.spyOn(api, 'updateMediaOffer').mockRejectedValue(new Error('Controlled error'));
+		vi.spyOn(api, 'updateMediaOffer').mockRejectedValue(controlledError);
 
 		const videoOutConn = useStore.getState().activeMeeting?.videoOutConn;
 		videoOutConn!.peerConn = {} as RTCPeerConnection;
@@ -139,10 +141,25 @@ describe('Camera button', () => {
 		await waitFor(() => expect(cameraButton).toBeEnabled());
 	});
 
+	test('Camera button is re-enabled when the media offer fails while starting video', async () => {
+		activeMeetingSetup(false);
+		vi.spyOn(UserMediaManager, 'getVideoStream').mockResolvedValue({
+			getVideoTracks: () => [{ stop: vi.fn() }]
+		} as unknown as MediaStream);
+		vi.spyOn(api, 'updateMediaOffer').mockRejectedValue(controlledError);
+
+		const { user } = routerContextSetup(cameraButtonComponent, { meetingId: mockMeeting.id });
+		const cameraButton = await screen.findByTestId('cameraButton');
+		await waitFor(() => expect(cameraButton).toBeEnabled());
+
+		await user.click(cameraButton);
+		await waitFor(() => expect(cameraButton).toBeEnabled());
+	});
+
 	test('Camera button is re-enabled when stopVideo fails', async () => {
 		activeMeetingSetup(true);
 		const videoOutConn = useStore.getState().activeMeeting?.videoOutConn;
-		vi.spyOn(videoOutConn!, 'stopVideo').mockRejectedValue(new Error('Controlled error'));
+		vi.spyOn(videoOutConn!, 'stopVideo').mockRejectedValue(controlledError);
 
 		const { user } = routerContextSetup(cameraButtonComponent, { meetingId: mockMeeting.id });
 		const cameraButton = await screen.findByTestId('cameraButton');

--- a/src/meetings/components/meetingActionsBar/CameraButton.test.tsx
+++ b/src/meetings/components/meetingActionsBar/CameraButton.test.tsx
@@ -5,11 +5,47 @@
  */
 import React from 'react';
 
-import { screen } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 
 import CameraButton from './CameraButton';
+import * as api from '../../../network/apis/MeetingsApi';
 import useStore from '../../../store/Store';
-import { setup } from '../../../tests/test-utils';
+import { createMockMeeting, createMockRoom } from '../../../tests/createMock';
+import { routerContextSetup, setup } from '../../../tests/test-utils';
+import { MeetingBe } from '../../../types/network/models/meetingBeTypes';
+import { RoomBe } from '../../../types/network/models/roomBeTypes';
+import { STREAM_TYPE } from '../../../types/store/ActiveMeetingTypes';
+import { RoomType } from '../../../types/store/RoomTypes';
+import * as UserMediaManager from '../../../utils/UserMediaManager';
+
+const mockMeeting: MeetingBe = createMockMeeting();
+const mockRoom: RoomBe = createMockRoom({
+	id: mockMeeting.roomId,
+	type: RoomType.GROUP,
+	members: [{ userId: 'userId', owner: true }]
+});
+
+const activeMeetingSetup = (videoStreamOn: boolean): void => {
+	const store = useStore.getState();
+	store.setLoginInfo({ id: 'userId', name: 'User' });
+	store.setWebsocketStatus(true);
+	store.addRooms([mockRoom]);
+	store.addMeetings([mockMeeting]);
+	store.addParticipant(mockMeeting.id, {
+		userId: 'userId',
+		videoStreamOn,
+		joinedAt: ''
+	});
+	store.meetingConnection(mockMeeting.id);
+};
+
+const cameraButtonComponent = (
+	<CameraButton
+		videoDropdownRef={React.createRef<HTMLDivElement>()}
+		isVideoListOpen={false}
+		setIsVideoListOpen={vi.fn()}
+	/>
+);
 
 describe('Camera button', () => {
 	test('Should render the component', async () => {
@@ -62,5 +98,57 @@ describe('Camera button', () => {
 		);
 		const cameraButton = await screen.findByTestId('cameraButton');
 		expect(cameraButton).toBeDisabled();
+	});
+
+	test('Camera button is disabled while enabling video and re-enabled when stream status updates', async () => {
+		activeMeetingSetup(false);
+		vi.spyOn(UserMediaManager, 'getVideoStream').mockResolvedValue({} as MediaStream);
+		vi.spyOn(api, 'updateMediaOffer').mockResolvedValue({} as Response);
+
+		const videoOutConn = useStore.getState().activeMeeting?.videoOutConn;
+		videoOutConn!.peerConn = {} as RTCPeerConnection;
+		vi.spyOn(videoOutConn!, 'updateLocalStreamTrack').mockResolvedValue({} as MediaStreamTrack);
+
+		const { user } = routerContextSetup(cameraButtonComponent, { meetingId: mockMeeting.id });
+		const cameraButton = await screen.findByTestId('cameraButton');
+		await waitFor(() => expect(cameraButton).toBeEnabled());
+
+		await user.click(cameraButton);
+		expect(cameraButton).toBeDisabled();
+
+		act(() => {
+			useStore.getState().changeStreamStatus(mockMeeting.id, 'userId', STREAM_TYPE.VIDEO, true);
+		});
+		expect(cameraButton).toBeEnabled();
+	});
+
+	test('Camera button is re-enabled when updateMediaOffer fails', async () => {
+		activeMeetingSetup(false);
+		vi.spyOn(UserMediaManager, 'getVideoStream').mockResolvedValue({} as MediaStream);
+		vi.spyOn(api, 'updateMediaOffer').mockRejectedValue(new Error('Controlled error'));
+
+		const videoOutConn = useStore.getState().activeMeeting?.videoOutConn;
+		videoOutConn!.peerConn = {} as RTCPeerConnection;
+		vi.spyOn(videoOutConn!, 'updateLocalStreamTrack').mockResolvedValue({} as MediaStreamTrack);
+
+		const { user } = routerContextSetup(cameraButtonComponent, { meetingId: mockMeeting.id });
+		const cameraButton = await screen.findByTestId('cameraButton');
+		await waitFor(() => expect(cameraButton).toBeEnabled());
+
+		await user.click(cameraButton);
+		await waitFor(() => expect(cameraButton).toBeEnabled());
+	});
+
+	test('Camera button is re-enabled when stopVideo fails', async () => {
+		activeMeetingSetup(true);
+		const videoOutConn = useStore.getState().activeMeeting?.videoOutConn;
+		vi.spyOn(videoOutConn!, 'stopVideo').mockRejectedValue(new Error('Controlled error'));
+
+		const { user } = routerContextSetup(cameraButtonComponent, { meetingId: mockMeeting.id });
+		const cameraButton = await screen.findByTestId('cameraButton');
+		await waitFor(() => expect(cameraButton).toBeEnabled());
+
+		await user.click(cameraButton);
+		await waitFor(() => expect(cameraButton).toBeEnabled());
 	});
 });

--- a/src/meetings/components/meetingActionsBar/CameraButton.tsx
+++ b/src/meetings/components/meetingActionsBar/CameraButton.tsx
@@ -106,28 +106,21 @@ const CameraButton = ({
 	);
 
 	const toggleVideoStream = useCallback(
-		(event: React.MouseEvent<HTMLButtonElement, MouseEvent> | KeyboardEvent) => {
+		async (event: React.MouseEvent<HTMLButtonElement, MouseEvent> | KeyboardEvent) => {
 			event.stopPropagation();
 			setButtonStatus(false);
-			if (!videoStatus) {
-				if (!videoOutConn?.peerConn) {
-					videoOutConn?.startVideo(selectedVideoDeviceId).catch(() => {
-						setButtonStatus(true);
-					});
+			try {
+				if (videoStatus) {
+					await videoOutConn?.stopVideo();
+				} else if (videoOutConn?.peerConn) {
+					const stream = await getVideoStream(selectedVideoDeviceId);
+					await videoOutConn?.updateLocalStreamTrack(stream);
+					await updateMediaOffer(meetingId!, STREAM_TYPE.VIDEO, true);
 				} else {
-					getVideoStream(selectedVideoDeviceId)
-						.then((stream) => {
-							videoOutConn
-								?.updateLocalStreamTrack(stream)
-								.then(() => updateMediaOffer(meetingId!, STREAM_TYPE.VIDEO, true));
-						})
-						.catch((e) => {
-							setButtonStatus(true);
-							console.log(e);
-						});
+					await videoOutConn?.startVideo(selectedVideoDeviceId);
 				}
-			} else {
-				videoOutConn?.stopVideo();
+			} catch {
+				setButtonStatus(true);
 			}
 		},
 		[videoStatus, videoOutConn, selectedVideoDeviceId, meetingId]

--- a/src/meetings/components/meetingActionsBar/MicrophoneButton.test.tsx
+++ b/src/meetings/components/meetingActionsBar/MicrophoneButton.test.tsx
@@ -5,13 +5,49 @@
  */
 import React from 'react';
 
-import { screen } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 
 import MicrophoneButton from './MicrophoneButton';
+import * as api from '../../../network/apis/MeetingsApi';
 import useStore from '../../../store/Store';
-import { setup } from '../../../tests/test-utils';
+import { createMockMeeting, createMockRoom } from '../../../tests/createMock';
+import { routerContextSetup, setup } from '../../../tests/test-utils';
+import { MeetingBe } from '../../../types/network/models/meetingBeTypes';
+import { RoomBe } from '../../../types/network/models/roomBeTypes';
+import { STREAM_TYPE } from '../../../types/store/ActiveMeetingTypes';
+import { RoomType } from '../../../types/store/RoomTypes';
+import * as UserMediaManager from '../../../utils/UserMediaManager';
 
 const buttonDataTestId = 'microphone-button';
+
+const mockMeeting: MeetingBe = createMockMeeting();
+const mockRoom: RoomBe = createMockRoom({
+	id: mockMeeting.roomId,
+	type: RoomType.GROUP,
+	members: [{ userId: 'userId', owner: true }]
+});
+
+const activeMeetingSetup = (audioStreamOn: boolean): void => {
+	const store = useStore.getState();
+	store.setLoginInfo({ id: 'userId', name: 'User' });
+	store.setWebsocketStatus(true);
+	store.addRooms([mockRoom]);
+	store.addMeetings([mockMeeting]);
+	store.addParticipant(mockMeeting.id, {
+		userId: 'userId',
+		audioStreamOn,
+		joinedAt: ''
+	});
+	store.meetingConnection(mockMeeting.id);
+};
+
+const microphoneButtonComponent = (
+	<MicrophoneButton
+		audioDropdownRef={React.createRef<HTMLDivElement>()}
+		isAudioListOpen={false}
+		setIsAudioListOpen={vi.fn()}
+	/>
+);
 
 describe('Microphone button', () => {
 	test('Should render the component', async () => {
@@ -62,5 +98,61 @@ describe('Microphone button', () => {
 			/>
 		);
 		expect(await screen.findByTestId(buttonDataTestId)).toBeDisabled();
+	});
+
+	test('Microphone button is disabled while enabling audio and re-enabled when stream status updates', async () => {
+		activeMeetingSetup(false);
+		vi.spyOn(UserMediaManager, 'getAudioStream').mockResolvedValue({} as MediaStream);
+		vi.spyOn(api, 'updateAudioStreamStatus').mockResolvedValue({} as Response);
+
+		const bidirectionalAudioConn = useStore.getState().activeMeeting?.bidirectionalAudioConn;
+		vi.spyOn(bidirectionalAudioConn!, 'updateLocalStreamTrack').mockResolvedValue(
+			{} as MediaStreamTrack
+		);
+
+		const { user } = routerContextSetup(microphoneButtonComponent, { meetingId: mockMeeting.id });
+		const microphoneButton = await screen.findByTestId(buttonDataTestId);
+		await waitFor(() => expect(microphoneButton).toBeEnabled());
+
+		await user.click(microphoneButton);
+		expect(microphoneButton).toBeDisabled();
+
+		act(() => {
+			useStore.getState().changeStreamStatus(mockMeeting.id, 'userId', STREAM_TYPE.AUDIO, true);
+		});
+		expect(microphoneButton).toBeEnabled();
+	});
+
+	test('Microphone button is re-enabled when updateAudioStreamStatus fails on enabling', async () => {
+		activeMeetingSetup(false);
+		vi.spyOn(UserMediaManager, 'getAudioStream').mockResolvedValue({} as MediaStream);
+		vi.spyOn(api, 'updateAudioStreamStatus').mockRejectedValue(new Error('Controlled error'));
+
+		const bidirectionalAudioConn = useStore.getState().activeMeeting?.bidirectionalAudioConn;
+		vi.spyOn(bidirectionalAudioConn!, 'updateLocalStreamTrack').mockResolvedValue(
+			{} as MediaStreamTrack
+		);
+
+		const { user } = routerContextSetup(microphoneButtonComponent, { meetingId: mockMeeting.id });
+		const microphoneButton = await screen.findByTestId(buttonDataTestId);
+		await waitFor(() => expect(microphoneButton).toBeEnabled());
+
+		await user.click(microphoneButton);
+		await waitFor(() => expect(microphoneButton).toBeEnabled());
+	});
+
+	test('Microphone button is re-enabled when updateAudioStreamStatus fails on disabling', async () => {
+		activeMeetingSetup(true);
+		vi.spyOn(api, 'updateAudioStreamStatus').mockRejectedValue(new Error('Controlled error'));
+
+		const bidirectionalAudioConn = useStore.getState().activeMeeting?.bidirectionalAudioConn;
+		vi.spyOn(bidirectionalAudioConn!, 'closeRtpSenderTrack').mockImplementation(() => {});
+
+		const { user } = routerContextSetup(microphoneButtonComponent, { meetingId: mockMeeting.id });
+		const microphoneButton = await screen.findByTestId(buttonDataTestId);
+		await waitFor(() => expect(microphoneButton).toBeEnabled());
+
+		await user.click(microphoneButton);
+		await waitFor(() => expect(microphoneButton).toBeEnabled());
 	});
 });

--- a/src/meetings/components/meetingActionsBar/MicrophoneButton.tsx
+++ b/src/meetings/components/meetingActionsBar/MicrophoneButton.tsx
@@ -10,7 +10,9 @@ import React, {
 	SetStateAction,
 	useCallback,
 	useContext,
-	useMemo
+	useEffect,
+	useMemo,
+	useState
 } from 'react';
 
 import { Tooltip } from '@zextras/carbonio-design-system';
@@ -64,6 +66,12 @@ const MicrophoneButton = ({
 
 	const { permission, deviceList, noDevices } = useMediaDevices('audio');
 
+	const [buttonStatus, setButtonStatus] = useState<boolean>(true);
+
+	useEffect(() => {
+		setButtonStatus(true);
+	}, [audioStatus]);
+
 	const onClickAudioItem = useCallback(
 		(audioItem: MediaDeviceInfo) => {
 			if (audioStatus) {
@@ -91,21 +99,20 @@ const MicrophoneButton = ({
 	);
 
 	const toggleAudioStream = useCallback(
-		(event: { stopPropagation: () => void }) => {
+		async (event: React.MouseEvent<HTMLButtonElement, MouseEvent> | KeyboardEvent) => {
 			event.stopPropagation();
-			if (!audioStatus) {
-				getAudioStream(selectedAudioDeviceId)
-					.then((stream) => {
-						bidirectionalAudioConn?.updateLocalStreamTrack(stream).then(() => {
-							updateAudioStreamStatus(meetingId!, !audioStatus);
-						});
-					})
-					.catch((e) => {
-						console.log(e);
-					});
-			} else {
-				bidirectionalAudioConn?.closeRtpSenderTrack();
-				updateAudioStreamStatus(meetingId!, !audioStatus);
+			setButtonStatus(false);
+			try {
+				if (!audioStatus) {
+					const stream = await getAudioStream(selectedAudioDeviceId);
+					await bidirectionalAudioConn?.updateLocalStreamTrack(stream);
+					await updateAudioStreamStatus(meetingId!, !audioStatus);
+				} else {
+					bidirectionalAudioConn?.closeRtpSenderTrack();
+					await updateAudioStreamStatus(meetingId!, !audioStatus);
+				}
+			} catch {
+				setButtonStatus(true);
 			}
 		},
 		[audioStatus, bidirectionalAudioConn, meetingId, selectedAudioDeviceId]
@@ -117,8 +124,13 @@ const MicrophoneButton = ({
 	}, [websocketNetworkStatus, disableButtonLabel, audioStatus, disableMicLabel, enableMicLabel]);
 
 	const disabled = useMemo(
-		() => !websocketNetworkStatus || !messageBrokerStatus || permission !== 'granted' || noDevices,
-		[messageBrokerStatus, noDevices, permission, websocketNetworkStatus]
+		() =>
+			!buttonStatus ||
+			!websocketNetworkStatus ||
+			!messageBrokerStatus ||
+			permission !== 'granted' ||
+			noDevices,
+		[buttonStatus, messageBrokerStatus, noDevices, permission, websocketNetworkStatus]
 	);
 
 	return (

--- a/src/meetings/components/mobile/MobileActionBar.test.tsx
+++ b/src/meetings/components/mobile/MobileActionBar.test.tsx
@@ -159,7 +159,7 @@ describe('MobileActionBar test', () => {
 		store.meetingConnection(mockMeeting.id);
 
 		const videoOutConn = useStore.getState().activeMeeting?.videoOutConn;
-		const stopVideoSpy = vi.spyOn(videoOutConn!, 'stopVideo').mockImplementation(() => {});
+		const stopVideoSpy = vi.spyOn(videoOutConn!, 'stopVideo').mockResolvedValue({} as Response);
 
 		const { user } = routerContextSetup(
 			<MobileActionBar

--- a/src/meetings/components/mobile/MobileActionBar.tsx
+++ b/src/meetings/components/mobile/MobileActionBar.tsx
@@ -4,7 +4,14 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import React, { Dispatch, ReactElement, SetStateAction, useCallback } from 'react';
+import React, {
+	Dispatch,
+	ReactElement,
+	SetStateAction,
+	useCallback,
+	useEffect,
+	useState
+} from 'react';
 
 import { Button, Container } from '@zextras/carbonio-design-system';
 
@@ -36,30 +43,47 @@ const MobileActionBar = ({ meetingId, view, setView }: MobileActionBarProps): Re
 	const bidirectionalAudioConn = useStore((store) => store.activeMeeting?.bidirectionalAudioConn);
 	const videoOutConn = useStore((store) => store.activeMeeting?.videoOutConn);
 
-	const toggleAudioStream = useCallback(() => {
-		if (!audioStatus) {
-			getAudioStream().then((stream) => {
-				bidirectionalAudioConn?.updateLocalStreamTrack(stream).then(() => {
-					updateAudioStreamStatus(meetingId, !audioStatus);
-				});
-			});
-		} else {
-			bidirectionalAudioConn?.closeRtpSenderTrack();
-			updateAudioStreamStatus(meetingId, !audioStatus);
+	const [audioButtonStatus, setAudioButtonStatus] = useState<boolean>(true);
+	const [videoButtonStatus, setVideoButtonStatus] = useState<boolean>(true);
+
+	useEffect(() => {
+		setAudioButtonStatus(true);
+	}, [audioStatus]);
+
+	useEffect(() => {
+		setVideoButtonStatus(true);
+	}, [videoStatus]);
+
+	const toggleAudioStream = useCallback(async () => {
+		setAudioButtonStatus(false);
+		try {
+			if (!audioStatus) {
+				const stream = await getAudioStream();
+				await bidirectionalAudioConn?.updateLocalStreamTrack(stream);
+				await updateAudioStreamStatus(meetingId, !audioStatus);
+			} else {
+				bidirectionalAudioConn?.closeRtpSenderTrack();
+				await updateAudioStreamStatus(meetingId, !audioStatus);
+			}
+		} catch {
+			setAudioButtonStatus(true);
 		}
 	}, [audioStatus, bidirectionalAudioConn, meetingId]);
 
-	const toggleVideoStream = useCallback(() => {
-		if (videoStatus) {
-			videoOutConn?.stopVideo();
-		} else if (videoOutConn?.peerConn) {
-			getFrontCameraStream().then((stream) => {
-				videoOutConn
-					?.updateLocalStreamTrack(stream)
-					.then(() => updateMediaOffer(meetingId, STREAM_TYPE.VIDEO, true));
-			});
-		} else {
-			videoOutConn?.startVideo();
+	const toggleVideoStream = useCallback(async () => {
+		setVideoButtonStatus(false);
+		try {
+			if (videoStatus) {
+				await videoOutConn?.stopVideo();
+			} else if (videoOutConn?.peerConn) {
+				const stream = await getFrontCameraStream();
+				await videoOutConn?.updateLocalStreamTrack(stream);
+				await updateMediaOffer(meetingId, STREAM_TYPE.VIDEO, true);
+			} else {
+				await videoOutConn?.startVideo();
+			}
+		} catch {
+			setVideoButtonStatus(true);
 		}
 	}, [videoStatus, videoOutConn, meetingId]);
 
@@ -94,8 +118,18 @@ const MobileActionBar = ({ meetingId, view, setView }: MobileActionBarProps): Re
 				icon={view === MobileMeetingView.CHAT ? 'Video' : 'MessageCircle'}
 				onClick={toggleChatView}
 			/>
-			<Button size="large" icon={audioStatus ? 'Mic' : 'MicOff'} onClick={toggleAudioStream} />
-			<Button size="large" icon={videoStatus ? 'Video' : 'VideoOff'} onClick={toggleVideoStream} />
+			<Button
+				size="large"
+				icon={audioStatus ? 'Mic' : 'MicOff'}
+				onClick={toggleAudioStream}
+				disabled={!audioButtonStatus}
+			/>
+			<Button
+				size="large"
+				icon={videoStatus ? 'Video' : 'VideoOff'}
+				onClick={toggleVideoStream}
+				disabled={!videoButtonStatus}
+			/>
 			<Button size="large" icon="LogOutOutline" color="error" onClick={leaveMeetingAction} />
 		</Container>
 	);

--- a/src/meetings/components/pictureInPicture/PictureInPictureView.tsx
+++ b/src/meetings/components/pictureInPicture/PictureInPictureView.tsx
@@ -98,24 +98,20 @@ const PictureInPictureView = (): ReactElement => {
 	);
 
 	const toggleVideoStream = useCallback(
-		(event: React.MouseEvent<HTMLButtonElement, MouseEvent> | KeyboardEvent) => {
+		async (event: React.MouseEvent<HTMLButtonElement, MouseEvent> | KeyboardEvent) => {
 			event.stopPropagation();
-			if (!videoStatus) {
-				if (!videoOutConn?.peerConn) {
-					videoOutConn?.startVideo(selectedVideoDeviceId).catch(() => {});
+			try {
+				if (videoStatus) {
+					await videoOutConn?.stopVideo();
+				} else if (videoOutConn?.peerConn) {
+					const stream = await getVideoStream(selectedVideoDeviceId);
+					await videoOutConn?.updateLocalStreamTrack(stream);
+					await updateMediaOffer(meetingId!, STREAM_TYPE.VIDEO, true);
 				} else {
-					getVideoStream(selectedVideoDeviceId)
-						.then((stream) => {
-							videoOutConn
-								?.updateLocalStreamTrack(stream)
-								.then(() => updateMediaOffer(meetingId!, STREAM_TYPE.VIDEO, true));
-						})
-						.catch((e) => {
-							console.log(e);
-						});
+					await videoOutConn?.startVideo();
 				}
-			} else {
-				videoOutConn?.stopVideo();
+			} catch (error) {
+				console.log(error);
 			}
 		},
 		[videoStatus, videoOutConn, selectedVideoDeviceId, meetingId]

--- a/src/meetings/components/pictureInPicture/PictureInPictureView.tsx
+++ b/src/meetings/components/pictureInPicture/PictureInPictureView.tsx
@@ -108,7 +108,7 @@ const PictureInPictureView = (): ReactElement => {
 					await videoOutConn?.updateLocalStreamTrack(stream);
 					await updateMediaOffer(meetingId!, STREAM_TYPE.VIDEO, true);
 				} else {
-					await videoOutConn?.startVideo();
+					await videoOutConn?.startVideo(selectedVideoDeviceId);
 				}
 			} catch (error) {
 				console.log(error);

--- a/src/network/webRTC/BidirectionalConnectionAudioInOut.test.ts
+++ b/src/network/webRTC/BidirectionalConnectionAudioInOut.test.ts
@@ -1,0 +1,131 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import BidirectionalConnectionAudioInOut from './BidirectionalConnectionAudioInOut';
+import * as UserMediaManager from '../../utils/UserMediaManager';
+import * as MeetingsApi from '../apis/MeetingsApi';
+
+const meetingId = 'meetingId';
+
+const flushPromises = async (): Promise<void> => {
+	for (let i = 0; i < 15; i += 1) {
+		// eslint-disable-next-line no-await-in-loop
+		await Promise.resolve();
+	}
+};
+
+const createPeerConnMock = (
+	overrides: Partial<Record<string, unknown>> = {}
+): Record<string, unknown> => ({
+	addTrack: vi.fn(() => ({
+		track: { stop: vi.fn() },
+		replaceTrack: vi.fn(() => Promise.resolve())
+	})),
+	createOffer: vi.fn(() => Promise.resolve({ sdp: 'sdp', type: 'offer' })),
+	setLocalDescription: vi.fn(() => Promise.resolve()),
+	setRemoteDescription: vi.fn(() => Promise.resolve()),
+	close: vi.fn(),
+	signalingState: 'stable',
+	connectionState: 'connected',
+	localDescription: { sdp: 'sdp' }
+});
+
+const mockAudioStream = {
+	getAudioTracks: (): { stop: () => void }[] => [{ stop: vi.fn() }]
+} as unknown as MediaStream;
+
+let peerConnMock: Record<string, unknown>;
+
+const setPeerConnMock = (overrides: Partial<Record<string, unknown>> = {}): void => {
+	peerConnMock = { ...createPeerConnMock(), ...overrides };
+	Object.defineProperty(window, 'RTCPeerConnection', {
+		configurable: true,
+		writable: true,
+		value: vi.fn(function RTCPeerConnectionMock() {
+			return peerConnMock;
+		})
+	});
+};
+
+beforeEach(() => {
+	setPeerConnMock();
+});
+
+describe('BidirectionalConnectionAudioInOut', () => {
+	test('Negotiates the audio offer on construction when audio is disabled', async () => {
+		const createAudioOfferSpy = vi
+			.spyOn(MeetingsApi, 'createAudioOffer')
+			.mockResolvedValue({} as Response);
+		const updateAudioStreamStatusSpy = vi
+			.spyOn(MeetingsApi, 'updateAudioStreamStatus')
+			.mockResolvedValue({} as Response);
+		const getAudioStreamSpy = vi.spyOn(UserMediaManager, 'getAudioStream');
+
+		// eslint-disable-next-line no-new
+		new BidirectionalConnectionAudioInOut(meetingId, false);
+		await flushPromises();
+
+		expect(createAudioOfferSpy).toHaveBeenCalledWith(meetingId, 'sdp');
+		expect(updateAudioStreamStatusSpy).toHaveBeenCalledWith(meetingId, false);
+		expect(getAudioStreamSpy).not.toHaveBeenCalled();
+	});
+
+	test('Acquires the audio stream on construction when audio is enabled', async () => {
+		vi.spyOn(MeetingsApi, 'createAudioOffer').mockResolvedValue({} as Response);
+		const updateAudioStreamStatusSpy = vi
+			.spyOn(MeetingsApi, 'updateAudioStreamStatus')
+			.mockResolvedValue({} as Response);
+		const getAudioStreamSpy = vi
+			.spyOn(UserMediaManager, 'getAudioStream')
+			.mockResolvedValue(mockAudioStream);
+
+		// eslint-disable-next-line no-new
+		new BidirectionalConnectionAudioInOut(meetingId, true, 'deviceId');
+		await flushPromises();
+
+		expect(getAudioStreamSpy).toHaveBeenCalledWith('deviceId');
+		expect(updateAudioStreamStatusSpy).toHaveBeenCalledWith(meetingId, true);
+	});
+
+	test('Skips negotiation when the signaling state is not stable', async () => {
+		setPeerConnMock({ signalingState: 'have-local-offer' });
+		const createAudioOfferSpy = vi
+			.spyOn(MeetingsApi, 'createAudioOffer')
+			.mockResolvedValue({} as Response);
+
+		// eslint-disable-next-line no-new
+		new BidirectionalConnectionAudioInOut(meetingId, false);
+		await flushPromises();
+
+		expect(peerConnMock.createOffer).toHaveBeenCalled();
+		expect(createAudioOfferSpy).not.toHaveBeenCalled();
+	});
+
+	test('Skips negotiation when the offer has no sdp', async () => {
+		setPeerConnMock({ createOffer: vi.fn(() => Promise.resolve({ type: 'offer' })) });
+		const createAudioOfferSpy = vi
+			.spyOn(MeetingsApi, 'createAudioOffer')
+			.mockResolvedValue({} as Response);
+
+		// eslint-disable-next-line no-new
+		new BidirectionalConnectionAudioInOut(meetingId, false);
+		await flushPromises();
+
+		expect(peerConnMock.setLocalDescription).toHaveBeenCalled();
+		expect(createAudioOfferSpy).not.toHaveBeenCalled();
+	});
+
+	test('handleRemoteAnswer sets the remote description when not in have-remote-offer state', async () => {
+		vi.spyOn(MeetingsApi, 'createAudioOffer').mockResolvedValue({} as Response);
+		vi.spyOn(MeetingsApi, 'updateAudioStreamStatus').mockResolvedValue({} as Response);
+
+		const conn = new BidirectionalConnectionAudioInOut(meetingId, false);
+		await flushPromises();
+
+		conn.handleRemoteAnswer({ sdp: 'sdp', type: 'answer' });
+		expect(peerConnMock.setRemoteDescription).toHaveBeenCalled();
+	});
+});

--- a/src/network/webRTC/BidirectionalConnectionAudioInOut.ts
+++ b/src/network/webRTC/BidirectionalConnectionAudioInOut.ts
@@ -48,11 +48,16 @@ export default class BidirectionalConnectionAudioInOut implements IBidirectional
 		this.oscillatorAudioTrack = first(oscillatorAudioTrack.getAudioTracks());
 
 		this.updateRemoteStreamAudio();
-		this.updateLocalStreamTrack(oscillatorAudioTrack)
+		this.init();
+	}
+
+	private init(): void {
+		if (!this.oscillatorAudioTrack) return;
+		this.updateLocalStreamTrack(new MediaStream([this.oscillatorAudioTrack]))
 			.then(() => this.negotiate())
 			.then(() => {
-				if (audioStreamEnabled) {
-					return getAudioStream(selectedAudioDeviceId).then((stream) => {
+				if (this.initialAudioStatus) {
+					return getAudioStream(this.selectedAudioDeviceId).then((stream) => {
 						this.updateLocalStreamTrack(stream);
 						useStore.getState().setLocalStreams(STREAM_TYPE.AUDIO, stream);
 					});
@@ -69,7 +74,7 @@ export default class BidirectionalConnectionAudioInOut implements IBidirectional
 	};
 
 	// Create the SDP offer, set it as local description and send it to the remote peer
-	private negotiate = async (): Promise<void> => {
+	private readonly negotiate = async (): Promise<void> => {
 		const offer = await this.peerConn.createOffer();
 		if (this.peerConn.signalingState !== 'stable') return;
 		await this.peerConn.setLocalDescription(offer);

--- a/src/network/webRTC/BidirectionalConnectionAudioInOut.ts
+++ b/src/network/webRTC/BidirectionalConnectionAudioInOut.ts
@@ -30,7 +30,6 @@ export default class BidirectionalConnectionAudioInOut implements IBidirectional
 	constructor(meetingId: string, audioStreamEnabled: boolean, selectedAudioDeviceId?: string) {
 		this.peerConn = new RTCPeerConnection(new PeerConnConfig().getConfig());
 		this.peerConn.ontrack = this.onTrack;
-		this.peerConn.onnegotiationneeded = this.onNegotiationNeeded;
 		this.peerConn.onconnectionstatechange = this.onConnectionStateChange;
 
 		this.meetingId = meetingId;
@@ -49,14 +48,18 @@ export default class BidirectionalConnectionAudioInOut implements IBidirectional
 		this.oscillatorAudioTrack = first(oscillatorAudioTrack.getAudioTracks());
 
 		this.updateRemoteStreamAudio();
-		this.updateLocalStreamTrack(oscillatorAudioTrack).then(() => {
-			if (audioStreamEnabled) {
-				getAudioStream(selectedAudioDeviceId).then((stream) => {
-					this.updateLocalStreamTrack(stream).then();
-					useStore.getState().setLocalStreams(STREAM_TYPE.AUDIO, stream);
-				});
-			}
-		});
+		this.updateLocalStreamTrack(oscillatorAudioTrack)
+			.then(() => this.negotiate())
+			.then(() => {
+				if (audioStreamEnabled) {
+					return getAudioStream(selectedAudioDeviceId).then((stream) => {
+						this.updateLocalStreamTrack(stream);
+						useStore.getState().setLocalStreams(STREAM_TYPE.AUDIO, stream);
+					});
+				}
+				return undefined;
+			})
+			.catch((reason) => console.warn(reason));
 	}
 
 	// Handle new tracks
@@ -65,25 +68,14 @@ export default class BidirectionalConnectionAudioInOut implements IBidirectional
 		this.updateRemoteStreamAudio();
 	};
 
-	// Create SDP offer, set it as local description and send it to the remote peer
-	onNegotiationNeeded = (): void => {
-		this.peerConn
-			.createOffer()
-			.then((rtcSessionDesc: RTCSessionDescriptionInit) => {
-				if (this.peerConn.signalingState === 'stable') {
-					this.peerConn
-						.setLocalDescription(rtcSessionDesc)
-						.then(() => {
-							if (rtcSessionDesc.sdp) {
-								createAudioOffer(this.meetingId, rtcSessionDesc.sdp).then(() => {
-									updateAudioStreamStatus(this.meetingId, this.initialAudioStatus);
-								});
-							}
-						})
-						.catch((reason) => console.warn(reason));
-				}
-			})
-			.catch((reason) => console.warn('createOffer failed', reason));
+	// Create the SDP offer, set it as local description and send it to the remote peer
+	private negotiate = async (): Promise<void> => {
+		const offer = await this.peerConn.createOffer();
+		if (this.peerConn.signalingState !== 'stable') return;
+		await this.peerConn.setLocalDescription(offer);
+		if (!offer.sdp) return;
+		await createAudioOffer(this.meetingId, offer.sdp);
+		await updateAudioStreamStatus(this.meetingId, this.initialAudioStatus);
 	};
 
 	private readonly onConnectionStateChange = (): void => {

--- a/src/network/webRTC/VideoOutConnection.test.ts
+++ b/src/network/webRTC/VideoOutConnection.test.ts
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import VideoOutConnection from './VideoOutConnection';
+import { STREAM_TYPE } from '../../types/store/ActiveMeetingTypes';
+import * as UserMediaManager from '../../utils/UserMediaManager';
+import * as MeetingsApi from '../apis/MeetingsApi';
+
+const meetingId = 'meetingId';
+
+const flushPromises = async (): Promise<void> => {
+	for (let i = 0; i < 15; i += 1) {
+		// eslint-disable-next-line no-await-in-loop
+		await Promise.resolve();
+	}
+};
+
+const createPeerConnMock = (
+	overrides: Partial<Record<string, unknown>> = {}
+): Record<string, unknown> => ({
+	addTrack: vi.fn(() => ({
+		track: { stop: vi.fn() },
+		replaceTrack: vi.fn(() => Promise.resolve())
+	})),
+	createOffer: vi.fn(() => Promise.resolve({ sdp: 'sdp', type: 'offer' })),
+	setLocalDescription: vi.fn(() => Promise.resolve()),
+	setRemoteDescription: vi.fn(() => Promise.resolve()),
+	close: vi.fn(),
+	signalingState: 'stable',
+	connectionState: 'connected',
+	localDescription: { sdp: 'sdp' },
+	...overrides
+});
+
+const mockVideoStream = {
+	getVideoTracks: (): { stop: () => void }[] => [{ stop: vi.fn() }]
+} as unknown as MediaStream;
+
+let peerConnMock: Record<string, unknown>;
+
+beforeEach(() => {
+	peerConnMock = createPeerConnMock();
+	Object.defineProperty(window, 'RTCPeerConnection', {
+		configurable: true,
+		writable: true,
+		value: vi.fn(function RTCPeerConnectionMock() {
+			return peerConnMock;
+		})
+	});
+});
+
+describe('VideoOutConnection', () => {
+	test('Does not start video when video stream is disabled', () => {
+		const getVideoStreamSpy = vi.spyOn(UserMediaManager, 'getVideoStream');
+		const conn = new VideoOutConnection(meetingId, false);
+		expect(conn.peerConn).toBeNull();
+		expect(getVideoStreamSpy).not.toHaveBeenCalled();
+	});
+
+	test('Starts video on construction when enabled and negotiates the offer', async () => {
+		vi.spyOn(UserMediaManager, 'getVideoStream').mockResolvedValue(mockVideoStream);
+		const updateMediaOfferSpy = vi
+			.spyOn(MeetingsApi, 'updateMediaOffer')
+			.mockResolvedValue({} as Response);
+
+		const conn = new VideoOutConnection(meetingId, true, 'deviceId');
+		await flushPromises();
+
+		expect(conn.peerConn).not.toBeNull();
+		expect(peerConnMock.createOffer).toHaveBeenCalled();
+		expect(peerConnMock.setLocalDescription).toHaveBeenCalled();
+		expect(updateMediaOfferSpy).toHaveBeenCalledWith(meetingId, STREAM_TYPE.VIDEO, true, 'sdp');
+	});
+
+	test('startVideo rejects and closes the peer connection when getVideoStream fails', async () => {
+		vi.spyOn(UserMediaManager, 'getVideoStream').mockRejectedValue(new Error('Controlled error'));
+
+		const conn = new VideoOutConnection(meetingId, false);
+		await expect(conn.startVideo('deviceId')).rejects.toThrow('Error while starting video');
+		expect(conn.peerConn).toBeNull();
+	});
+
+	test('stopVideo closes the connection and notifies the server', async () => {
+		const updateMediaOfferSpy = vi
+			.spyOn(MeetingsApi, 'updateMediaOffer')
+			.mockResolvedValue({} as Response);
+
+		const conn = new VideoOutConnection(meetingId, false);
+		await conn.stopVideo();
+
+		expect(conn.peerConn).toBeNull();
+		expect(updateMediaOfferSpy).toHaveBeenCalledWith(meetingId, STREAM_TYPE.VIDEO, false);
+	});
+
+	test('handleRemoteAnswer sets the remote description', async () => {
+		vi.spyOn(UserMediaManager, 'getVideoStream').mockResolvedValue(mockVideoStream);
+		vi.spyOn(MeetingsApi, 'updateMediaOffer').mockResolvedValue({} as Response);
+
+		const conn = new VideoOutConnection(meetingId, true);
+		await flushPromises();
+
+		conn.handleRemoteAnswer({ sdp: 'sdp', type: 'answer' });
+		expect(peerConnMock.setRemoteDescription).toHaveBeenCalled();
+	});
+});

--- a/src/network/webRTC/VideoOutConnection.ts
+++ b/src/network/webRTC/VideoOutConnection.ts
@@ -22,13 +22,20 @@ export default class VideoOutConnection implements IVideoOutConnection {
 
 	selectedVideoDeviceId: string | undefined;
 
+	private readonly videoStreamEnabled: boolean;
+
 	constructor(meetingId: string, videoStreamEnabled: boolean, selectedVideoDeviceId?: string) {
 		this.peerConn = null;
 		this.meetingId = meetingId;
 		this.rtpSender = null;
+		this.selectedVideoDeviceId = selectedVideoDeviceId;
+		this.videoStreamEnabled = videoStreamEnabled;
+		this.init();
+	}
 
-		if (videoStreamEnabled) {
-			this.startVideo(selectedVideoDeviceId).catch((reason) => console.warn(reason));
+	private init(): void {
+		if (this.videoStreamEnabled) {
+			this.startVideo(this.selectedVideoDeviceId).catch((reason) => console.warn(reason));
 		}
 	}
 
@@ -56,7 +63,7 @@ export default class VideoOutConnection implements IVideoOutConnection {
 	}
 
 	// Create the SDP offer, set it as local description and send it to the remote peer
-	private negotiate = async (): Promise<void> => {
+	private readonly negotiate = async (): Promise<void> => {
 		if (!this.peerConn) throw new Error('Missing peer connection');
 		const offer = await this.peerConn.createOffer();
 		await this.peerConn.setLocalDescription(offer);

--- a/src/network/webRTC/VideoOutConnection.ts
+++ b/src/network/webRTC/VideoOutConnection.ts
@@ -28,28 +28,26 @@ export default class VideoOutConnection implements IVideoOutConnection {
 		this.rtpSender = null;
 
 		if (videoStreamEnabled) {
-			this.startVideo(selectedVideoDeviceId);
+			this.startVideo(selectedVideoDeviceId).catch((reason) => console.warn(reason));
 		}
 	}
 
 	public startVideo(selectedVideoDeviceId?: string): Promise<void> {
-		return new Promise((resolve, reject) => {
-			this.peerConn = new RTCPeerConnection(new PeerConnConfig().getConfig());
-			this.peerConn.onnegotiationneeded = this.onNegotiationNeeded;
-			this.peerConn.onconnectionstatechange = this.onConnectionStateChange;
+		this.peerConn = new RTCPeerConnection(new PeerConnConfig().getConfig());
+		this.peerConn.onconnectionstatechange = this.onConnectionStateChange;
 
-			if (selectedVideoDeviceId) this.selectedVideoDeviceId = selectedVideoDeviceId;
+		if (selectedVideoDeviceId) this.selectedVideoDeviceId = selectedVideoDeviceId;
 
-			getVideoStream(selectedVideoDeviceId)
-				.then((stream) => {
-					this.updateLocalStreamTrack(stream);
-					useStore.getState().setLocalStreams(STREAM_TYPE.VIDEO, stream);
-					resolve();
-				})
-				.catch((err) => {
-					reject(new Error(`Error while requesting video track, reason: ${err}`));
-				});
-		});
+		return getVideoStream(selectedVideoDeviceId)
+			.then((stream) => {
+				this.updateLocalStreamTrack(stream);
+				useStore.getState().setLocalStreams(STREAM_TYPE.VIDEO, stream);
+				return this.negotiate();
+			})
+			.catch((err) => {
+				this.closePeerConnection();
+				throw new Error(`Error while starting video, reason: ${err}`);
+			});
 	}
 
 	public stopVideo(): Promise<Response> {
@@ -57,19 +55,12 @@ export default class VideoOutConnection implements IVideoOutConnection {
 		return updateMediaOffer(this.meetingId, STREAM_TYPE.VIDEO, false);
 	}
 
-	// Create SDP offer, set it as local description and send it to the remote peer
-	private onNegotiationNeeded = (): void => {
-		this.peerConn
-			?.createOffer()
-			.then((rtcSessionDesc: RTCSessionDescriptionInit) => {
-				this.peerConn
-					?.setLocalDescription(rtcSessionDesc)
-					.then(() => {
-						updateMediaOffer(this.meetingId, STREAM_TYPE.VIDEO, true, rtcSessionDesc.sdp);
-					})
-					.catch((reason) => console.warn(reason));
-			})
-			.catch((reason) => console.warn('createOffer failed', reason));
+	// Create the SDP offer, set it as local description and send it to the remote peer
+	private negotiate = async (): Promise<void> => {
+		if (!this.peerConn) throw new Error('Missing peer connection');
+		const offer = await this.peerConn.createOffer();
+		await this.peerConn.setLocalDescription(offer);
+		await updateMediaOffer(this.meetingId, STREAM_TYPE.VIDEO, true, offer.sdp);
 	};
 
 	private readonly onConnectionStateChange = (): void => {

--- a/src/network/webRTC/VideoOutConnection.ts
+++ b/src/network/webRTC/VideoOutConnection.ts
@@ -52,9 +52,9 @@ export default class VideoOutConnection implements IVideoOutConnection {
 		});
 	}
 
-	public stopVideo(): void {
+	public stopVideo(): Promise<Response> {
 		this.closePeerConnection();
-		updateMediaOffer(this.meetingId, STREAM_TYPE.VIDEO, false);
+		return updateMediaOffer(this.meetingId, STREAM_TYPE.VIDEO, false);
 	}
 
 	// Create SDP offer, set it as local description and send it to the remote peer

--- a/src/tests/setupTests.ts
+++ b/src/tests/setupTests.ts
@@ -32,6 +32,7 @@ Object.defineProperty(window, 'RTCPeerConnection', {
 	value: vi.fn(function RTCPeerConnectionMock() {
 		return {
 			addTrack: vi.fn(),
+			createOffer: vi.fn(() => Promise.resolve({ sdp: 'sdp', type: 'offer' })),
 			createAnswer: vi.fn(() => Promise.resolve({ sdp: '', type: 'answer' })),
 			setRemoteDescription: vi.fn(() => Promise.resolve()),
 			setLocalDescription: vi.fn(() => Promise.resolve())

--- a/src/tests/setupTests.ts
+++ b/src/tests/setupTests.ts
@@ -29,6 +29,7 @@ vi.mock('darkreader');
 vi.mock('react-router-dom');
 
 Object.defineProperty(window, 'RTCPeerConnection', {
+	configurable: true,
 	value: vi.fn(function RTCPeerConnectionMock() {
 		return {
 			addTrack: vi.fn(),

--- a/src/types/network/webRTC/webRTC.ts
+++ b/src/types/network/webRTC/webRTC.ts
@@ -36,7 +36,7 @@ export interface IVideoOutConnection extends IPeerConnection {
 	rtpSender: RTCRtpSender | null;
 	selectedVideoDeviceId: string | undefined;
 	startVideo(selectedVideoDeviceId?: string): Promise<void>;
-	stopVideo(): void;
+	stopVideo(): Promise<Response>;
 	handleRemoteAnswer(remoteAnswer: RTCSessionDescriptionInit): void;
 	updateLocalStreamTrack(
 		mediaStreamTrack: MediaStream,

--- a/src/types/network/webRTC/webRTC.ts
+++ b/src/types/network/webRTC/webRTC.ts
@@ -25,7 +25,6 @@ export interface IBidirectionalConnectionAudioInOut extends IPeerConnection {
 	initialAudioStatus: boolean;
 	oscillatorAudioTrack: MediaStreamTrack | undefined;
 	onTrack: (trackEvent: RTCTrackEvent) => void;
-	onNegotiationNeeded: () => void;
 	handleRemoteAnswer(remoteAnswer: RTCSessionDescriptionInit): void;
 	updateLocalStreamTrack(mediaStreamTrack: MediaStream): Promise<MediaStreamTrack>;
 	updateRemoteStreamAudio(): void;


### PR DESCRIPTION
During a call, if toggling audio or video failed (API error, WebRTC negotiation failure, connection drop), the toggle buttons got stuck and stopped responding to clicks: the user had to leave the call to recover. The cause: the button's "pending" state was only reset once the stream status was confirmed, and on failure that confirmation never arrived.

What was done:
- Rewrote the toggle handlers (`CameraButton`, `MicrophoneButton`, `MobileActionBar`, `PictureInPictureView`) as async/await with a single try/catch that re-enables the button on any failure.
- `VideoOutConnection` and `BidirectionalConnectionAudioInOut` now negotiate the offer explicitly and reliably (via a negotiate() method) instead of relying on the fire-and-forget onnegotiationneeded event: this way startVideo fails in a propagable manner and the button's try/catch can recover.