### PR TITLE
fix: address review findings on Bluetooth mute/unmute [CO-3829]

### DIFF
--- a/src/meetings/components/meetingActionsBar/MicrophoneButton.test.tsx
+++ b/src/meetings/components/meetingActionsBar/MicrophoneButton.test.tsx
@@ -125,6 +125,9 @@ describe('Microphone button', () => {
 
 		const bidirectionalAudioConn = useStore.getState().activeMeeting?.bidirectionalAudioConn;
 		vi.spyOn(bidirectionalAudioConn!, 'unmuteAudioTrack').mockResolvedValue();
+		const muteAudioTrack = vi
+			.spyOn(bidirectionalAudioConn!, 'muteAudioTrack')
+			.mockImplementation(() => {});
 
 		const { user } = routerContextSetup(microphoneButtonComponent, { meetingId: mockMeeting.id });
 		const microphoneButton = await screen.findByTestId(buttonDataTestId);
@@ -132,6 +135,8 @@ describe('Microphone button', () => {
 
 		await user.click(microphoneButton);
 		await waitFor(() => expect(microphoneButton).toBeEnabled());
+		// The local track state is rolled back to muted
+		expect(muteAudioTrack).toHaveBeenCalled();
 	});
 
 	test('Microphone button is re-enabled when updateAudioStreamStatus fails on disabling', async () => {
@@ -140,6 +145,9 @@ describe('Microphone button', () => {
 
 		const bidirectionalAudioConn = useStore.getState().activeMeeting?.bidirectionalAudioConn;
 		vi.spyOn(bidirectionalAudioConn!, 'muteAudioTrack').mockImplementation(() => {});
+		const unmuteAudioTrack = vi
+			.spyOn(bidirectionalAudioConn!, 'unmuteAudioTrack')
+			.mockResolvedValue();
 
 		const { user } = routerContextSetup(microphoneButtonComponent, { meetingId: mockMeeting.id });
 		const microphoneButton = await screen.findByTestId(buttonDataTestId);
@@ -147,5 +155,7 @@ describe('Microphone button', () => {
 
 		await user.click(microphoneButton);
 		await waitFor(() => expect(microphoneButton).toBeEnabled());
+		// The local track state is rolled back to unmuted
+		expect(unmuteAudioTrack).toHaveBeenCalled();
 	});
 });

--- a/src/meetings/components/meetingActionsBar/MicrophoneButton.tsx
+++ b/src/meetings/components/meetingActionsBar/MicrophoneButton.tsx
@@ -16,7 +16,7 @@ import React, {
 } from 'react';
 
 import { Tooltip } from '@zextras/carbonio-design-system';
-import { map } from 'lodash';
+import { first, map } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { MultiActionButton } from './MultiActionButton';
@@ -74,15 +74,18 @@ const MicrophoneButton = ({
 
 	const onClickAudioItem = useCallback(
 		(audioItem: MediaDeviceInfo) => {
-			getAudioStream(audioItem.deviceId).then((stream) => {
-				bidirectionalAudioConn?.updateLocalStreamTrack(stream).then((track) => {
+			getAudioStream(audioItem.deviceId)
+				.then((stream) => {
+					const track = first(stream.getAudioTracks());
+					// Disable the track before attaching it to the sender
+					// so that no audio frame can leak while muted
 					if (!audioStatus && track) {
-						// eslint-disable-next-line no-param-reassign
 						track.enabled = false;
 					}
-				});
-				setSelectedDeviceId(STREAM_TYPE.AUDIO, audioItem.deviceId);
-			});
+					setSelectedDeviceId(STREAM_TYPE.AUDIO, audioItem.deviceId);
+					return bidirectionalAudioConn?.updateLocalStreamTrack(stream);
+				})
+				.catch((reason) => console.error(reason));
 		},
 		[audioStatus, bidirectionalAudioConn, setSelectedDeviceId]
 	);
@@ -112,6 +115,13 @@ const MicrophoneButton = ({
 					await updateAudioStreamStatus(meetingId!, !audioStatus);
 				}
 			} catch {
+				// Roll back the local track state to keep it consistent
+				// with the server-side status that failed to update
+				if (audioStatus) {
+					bidirectionalAudioConn?.unmuteAudioTrack(selectedAudioDeviceId).catch(() => undefined);
+				} else {
+					bidirectionalAudioConn?.muteAudioTrack();
+				}
 				setButtonStatus(true);
 			}
 		},

--- a/src/meetings/components/mobile/MobileActionBar.tsx
+++ b/src/meetings/components/mobile/MobileActionBar.tsx
@@ -65,6 +65,13 @@ const MobileActionBar = ({ meetingId, view, setView }: MobileActionBarProps): Re
 				await updateAudioStreamStatus(meetingId, !audioStatus);
 			}
 		} catch {
+			// Roll back the local track state to keep it consistent
+			// with the server-side status that failed to update
+			if (audioStatus) {
+				bidirectionalAudioConn?.unmuteAudioTrack().catch(() => undefined);
+			} else {
+				bidirectionalAudioConn?.muteAudioTrack();
+			}
 			setAudioButtonStatus(true);
 		}
 	}, [audioStatus, bidirectionalAudioConn, meetingId]);

--- a/src/meetings/components/pictureInPicture/PictureInPictureView.tsx
+++ b/src/meetings/components/pictureInPicture/PictureInPictureView.tsx
@@ -77,20 +77,25 @@ const PictureInPictureView = (): ReactElement => {
 	}, [whoIsSpeaking]);
 
 	const toggleAudioStream = useCallback(
-		(event: { stopPropagation: () => void }) => {
+		async (event: { stopPropagation: () => void }) => {
 			event.stopPropagation();
-			if (!audioStatus) {
-				bidirectionalAudioConn
-					?.unmuteAudioTrack(selectedAudioDeviceId)
-					.then(() => {
-						updateAudioStreamStatus(meetingId!, !audioStatus);
-					})
-					.catch((e) => {
-						console.log(e);
-					});
-			} else {
-				bidirectionalAudioConn?.muteAudioTrack();
-				updateAudioStreamStatus(meetingId!, !audioStatus);
+			try {
+				if (!audioStatus) {
+					await bidirectionalAudioConn?.unmuteAudioTrack(selectedAudioDeviceId);
+					await updateAudioStreamStatus(meetingId!, !audioStatus);
+				} else {
+					bidirectionalAudioConn?.muteAudioTrack();
+					await updateAudioStreamStatus(meetingId!, !audioStatus);
+				}
+			} catch (e) {
+				// Roll back the local track state to keep it consistent
+				// with the server-side status that failed to update
+				if (audioStatus) {
+					bidirectionalAudioConn?.unmuteAudioTrack(selectedAudioDeviceId).catch(() => undefined);
+				} else {
+					bidirectionalAudioConn?.muteAudioTrack();
+				}
+				console.error(e);
 			}
 		},
 		[audioStatus, bidirectionalAudioConn, meetingId, selectedAudioDeviceId]

--- a/src/network/webRTC/BidirectionalConnectionAudioInOut.test.ts
+++ b/src/network/webRTC/BidirectionalConnectionAudioInOut.test.ts
@@ -17,13 +17,35 @@ const flushPromises = async (): Promise<void> => {
 	}
 };
 
-const createPeerConnMock = (
-	overrides: Partial<Record<string, unknown>> = {}
-): Record<string, unknown> => ({
-	addTrack: vi.fn(() => ({
-		track: { stop: vi.fn() },
-		replaceTrack: vi.fn(() => Promise.resolve())
-	})),
+type MockAudioTrack = {
+	stop: ReturnType<typeof vi.fn>;
+	enabled: boolean;
+	readyState: MediaStreamTrackState;
+};
+
+type MockSender = {
+	track: unknown;
+	replaceTrack: ReturnType<typeof vi.fn>;
+};
+
+const createMockAudioTrack = (readyState: MediaStreamTrackState = 'live'): MockAudioTrack => ({
+	stop: vi.fn(),
+	enabled: true,
+	readyState
+});
+
+const createMockAudioStream = (track: MockAudioTrack): MediaStream =>
+	({ getAudioTracks: (): Array<MockAudioTrack> => [track] }) as unknown as MediaStream;
+
+let senderMock: MockSender;
+
+// The sender keeps track of the last track passed to addTrack/replaceTrack
+// so tests can assert on the identity and enabled state of the sender track
+const createPeerConnMock = (): Record<string, unknown> => ({
+	addTrack: vi.fn((track: unknown) => {
+		senderMock.track = track;
+		return senderMock;
+	}),
 	createOffer: vi.fn(() => Promise.resolve({ sdp: 'sdp', type: 'offer' })),
 	setLocalDescription: vi.fn(() => Promise.resolve()),
 	setRemoteDescription: vi.fn(() => Promise.resolve()),
@@ -33,13 +55,16 @@ const createPeerConnMock = (
 	localDescription: { sdp: 'sdp' }
 });
 
-const mockAudioStream = {
-	getAudioTracks: (): { stop: () => void }[] => [{ stop: vi.fn() }]
-} as unknown as MediaStream;
-
 let peerConnMock: Record<string, unknown>;
 
 const setPeerConnMock = (overrides: Partial<Record<string, unknown>> = {}): void => {
+	senderMock = {
+		track: null,
+		replaceTrack: vi.fn((track: unknown) => {
+			senderMock.track = track;
+			return Promise.resolve();
+		})
+	};
 	peerConnMock = { ...createPeerConnMock(), ...overrides };
 	Object.defineProperty(window, 'RTCPeerConnection', {
 		configurable: true,
@@ -50,7 +75,13 @@ const setPeerConnMock = (overrides: Partial<Record<string, unknown>> = {}): void
 	});
 };
 
+// In the test environment the oscillator placeholder track resolves to the
+// window.MediaStream mock function itself (see setupTests): glue on it the
+// track API the connection uses when replacing the placeholder
+const placeholderTrack = window.MediaStream as unknown as MockAudioTrack;
+
 beforeEach(() => {
+	Object.assign(window.MediaStream, { stop: vi.fn(), readyState: 'live' });
 	setPeerConnMock();
 });
 
@@ -64,7 +95,7 @@ describe('BidirectionalConnectionAudioInOut', () => {
 			.mockResolvedValue({} as Response);
 		const getAudioStreamSpy = vi
 			.spyOn(UserMediaManager, 'getAudioStream')
-			.mockResolvedValue(mockAudioStream);
+			.mockResolvedValue(createMockAudioStream(createMockAudioTrack()));
 
 		// eslint-disable-next-line no-new
 		new BidirectionalConnectionAudioInOut(meetingId, false);
@@ -83,7 +114,7 @@ describe('BidirectionalConnectionAudioInOut', () => {
 			.mockResolvedValue({} as Response);
 		const getAudioStreamSpy = vi
 			.spyOn(UserMediaManager, 'getAudioStream')
-			.mockResolvedValue(mockAudioStream);
+			.mockResolvedValue(createMockAudioStream(createMockAudioTrack()));
 
 		// eslint-disable-next-line no-new
 		new BidirectionalConnectionAudioInOut(meetingId, true, 'deviceId');
@@ -130,5 +161,130 @@ describe('BidirectionalConnectionAudioInOut', () => {
 
 		conn.handleRemoteAnswer({ sdp: 'sdp', type: 'answer' });
 		expect(peerConnMock.setRemoteDescription).toHaveBeenCalled();
+	});
+
+	test('Acquires the audio stream but keeps the track disabled when joining muted', async () => {
+		vi.spyOn(MeetingsApi, 'createAudioOffer').mockResolvedValue({} as Response);
+		vi.spyOn(MeetingsApi, 'updateAudioStreamStatus').mockResolvedValue({} as Response);
+		const track = createMockAudioTrack();
+		vi.spyOn(UserMediaManager, 'getAudioStream').mockResolvedValue(createMockAudioStream(track));
+
+		// eslint-disable-next-line no-new
+		new BidirectionalConnectionAudioInOut(meetingId, false);
+		await flushPromises();
+
+		expect(senderMock.track).toBe(track);
+		expect(track.enabled).toBe(false);
+	});
+
+	test('muteAudioTrack disables the sender track without stopping it', async () => {
+		vi.spyOn(MeetingsApi, 'createAudioOffer').mockResolvedValue({} as Response);
+		vi.spyOn(MeetingsApi, 'updateAudioStreamStatus').mockResolvedValue({} as Response);
+		const track = createMockAudioTrack();
+		vi.spyOn(UserMediaManager, 'getAudioStream').mockResolvedValue(createMockAudioStream(track));
+
+		const conn = new BidirectionalConnectionAudioInOut(meetingId, true);
+		await flushPromises();
+		expect(track.enabled).toBe(true);
+
+		conn.muteAudioTrack();
+
+		expect(track.enabled).toBe(false);
+		expect(track.stop).not.toHaveBeenCalled();
+	});
+
+	test('unmuteAudioTrack re-enables the live microphone track without a new acquisition', async () => {
+		vi.spyOn(MeetingsApi, 'createAudioOffer').mockResolvedValue({} as Response);
+		vi.spyOn(MeetingsApi, 'updateAudioStreamStatus').mockResolvedValue({} as Response);
+		const track = createMockAudioTrack();
+		const getAudioStreamSpy = vi
+			.spyOn(UserMediaManager, 'getAudioStream')
+			.mockResolvedValue(createMockAudioStream(track));
+
+		const conn = new BidirectionalConnectionAudioInOut(meetingId, true);
+		await flushPromises();
+		conn.muteAudioTrack();
+
+		await conn.unmuteAudioTrack();
+
+		expect(track.enabled).toBe(true);
+		// Only the acquisition done by init(), none on unmute
+		expect(getAudioStreamSpy).toHaveBeenCalledTimes(1);
+	});
+
+	test('unmuteAudioTrack acquires a new stream when the sender track has ended', async () => {
+		vi.spyOn(MeetingsApi, 'createAudioOffer').mockResolvedValue({} as Response);
+		vi.spyOn(MeetingsApi, 'updateAudioStreamStatus').mockResolvedValue({} as Response);
+		const initTrack = createMockAudioTrack();
+		const newTrack = createMockAudioTrack();
+		const getAudioStreamSpy = vi
+			.spyOn(UserMediaManager, 'getAudioStream')
+			.mockResolvedValueOnce(createMockAudioStream(initTrack))
+			.mockResolvedValueOnce(createMockAudioStream(newTrack));
+
+		const conn = new BidirectionalConnectionAudioInOut(meetingId, true);
+		await flushPromises();
+		conn.muteAudioTrack();
+		initTrack.readyState = 'ended';
+
+		await conn.unmuteAudioTrack();
+
+		expect(getAudioStreamSpy).toHaveBeenCalledTimes(2);
+		expect(senderMock.track).toBe(newTrack);
+		expect(newTrack.enabled).toBe(true);
+	});
+
+	test('unmuteAudioTrack acquires the microphone instead of enabling the oscillator placeholder', async () => {
+		// init() logs the failed acquisition
+		const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		vi.spyOn(MeetingsApi, 'createAudioOffer').mockResolvedValue({} as Response);
+		vi.spyOn(MeetingsApi, 'updateAudioStreamStatus').mockResolvedValue({} as Response);
+		const micTrack = createMockAudioTrack();
+		const getAudioStreamSpy = vi
+			.spyOn(UserMediaManager, 'getAudioStream')
+			.mockRejectedValueOnce(new Error('Permission denied'))
+			.mockResolvedValueOnce(createMockAudioStream(micTrack));
+
+		// init() fails to acquire the microphone: the sender track is still the placeholder
+		const conn = new BidirectionalConnectionAudioInOut(meetingId, false);
+		await flushPromises();
+		expect(consoleWarn).toHaveBeenCalled();
+		expect(senderMock.track).toBe(placeholderTrack);
+
+		await conn.unmuteAudioTrack();
+
+		expect(getAudioStreamSpy).toHaveBeenCalledTimes(2);
+		expect(senderMock.track).toBe(micTrack);
+		expect(micTrack.enabled).toBe(true);
+		// The oscillator placeholder must never be enabled
+		expect(placeholderTrack.enabled).toBe(false);
+	});
+
+	test('Unmute requested while init is still acquiring the microphone ends with an enabled track', async () => {
+		vi.spyOn(MeetingsApi, 'createAudioOffer').mockResolvedValue({} as Response);
+		vi.spyOn(MeetingsApi, 'updateAudioStreamStatus').mockResolvedValue({} as Response);
+		const initTrack = createMockAudioTrack();
+		const unmuteTrack = createMockAudioTrack();
+		let resolveInitStream: ((stream: MediaStream) => void) | undefined;
+		vi.spyOn(UserMediaManager, 'getAudioStream')
+			.mockImplementationOnce(
+				() =>
+					new Promise((resolve) => {
+						resolveInitStream = resolve;
+					})
+			)
+			.mockResolvedValueOnce(createMockAudioStream(unmuteTrack));
+
+		const conn = new BidirectionalConnectionAudioInOut(meetingId, false);
+		await flushPromises();
+
+		// The user unmutes while init() is still acquiring the microphone
+		const unmutePromise = conn.unmuteAudioTrack();
+		resolveInitStream?.(createMockAudioStream(initTrack));
+		await unmutePromise;
+		await flushPromises();
+
+		// Whichever acquisition wins, the sender track must end up enabled
+		expect((senderMock.track as MockAudioTrack).enabled).toBe(true);
 	});
 });

--- a/src/network/webRTC/BidirectionalConnectionAudioInOut.ts
+++ b/src/network/webRTC/BidirectionalConnectionAudioInOut.ts
@@ -27,6 +27,13 @@ export default class BidirectionalConnectionAudioInOut implements IBidirectional
 
 	oscillatorAudioTrack: MediaStreamTrack | undefined;
 
+	// Reference to the oscillator placeholder track, never reassigned:
+	// used to tell the real microphone track apart from the placeholder
+	private readonly placeholderAudioTrack: MediaStreamTrack | undefined;
+
+	// Desired mute state, read when async stream acquisitions resolve
+	private muted: boolean;
+
 	constructor(meetingId: string, audioStreamEnabled: boolean, selectedAudioDeviceId?: string) {
 		this.peerConn = new RTCPeerConnection(new PeerConnConfig().getConfig());
 		this.peerConn.ontrack = this.onTrack;
@@ -36,6 +43,7 @@ export default class BidirectionalConnectionAudioInOut implements IBidirectional
 		this.rtpSender = null;
 		this.selectedAudioDeviceId = selectedAudioDeviceId;
 		this.initialAudioStatus = audioStreamEnabled;
+		this.muted = !audioStreamEnabled;
 
 		const audioCtx: AudioContext = new window.AudioContext();
 		const oscillator: OscillatorNode = audioCtx.createOscillator();
@@ -46,6 +54,7 @@ export default class BidirectionalConnectionAudioInOut implements IBidirectional
 		const audioTrack = Object.assign(dst.stream.getAudioTracks()[0], { enabled: false });
 		const oscillatorAudioTrack: MediaStream = new MediaStream([audioTrack]);
 		this.oscillatorAudioTrack = first(oscillatorAudioTrack.getAudioTracks());
+		this.placeholderAudioTrack = this.oscillatorAudioTrack;
 
 		this.updateRemoteStreamAudio();
 		this.init();
@@ -56,17 +65,10 @@ export default class BidirectionalConnectionAudioInOut implements IBidirectional
 		this.updateLocalStreamTrack(new MediaStream([this.oscillatorAudioTrack]))
 			.then(() => this.negotiate())
 			.then(() =>
-				getAudioStream(this.selectedAudioDeviceId).then((stream) => {
-					this.updateLocalStreamTrack(stream).then((track) => {
-						// If starting muted, disable the track but keep it alive
-						// to maintain Bluetooth HFP profile
-						if (!this.initialAudioStatus && track) {
-							// eslint-disable-next-line no-param-reassign
-							track.enabled = false;
-						}
-					});
-					useStore.getState().setLocalStreams(STREAM_TYPE.AUDIO, stream);
-				})
+				// The stream is acquired even when starting muted, to keep the
+				// Bluetooth HFP profile active and avoid the 1-2 second audio gap
+				// caused by A2DP ↔ HFP profile switching on unmute
+				getAudioStream(this.selectedAudioDeviceId).then((stream) => this.applyAudioStream(stream))
 			)
 			.catch((reason) => console.warn(reason));
 	}
@@ -84,7 +86,9 @@ export default class BidirectionalConnectionAudioInOut implements IBidirectional
 		await this.peerConn.setLocalDescription(offer);
 		if (!offer.sdp) return;
 		await createAudioOffer(this.meetingId, offer.sdp);
-		await updateAudioStreamStatus(this.meetingId, this.initialAudioStatus);
+		// Read the current muted state (not initialAudioStatus) to honor a
+		// mute/unmute requested while the negotiation was still in flight
+		await updateAudioStreamStatus(this.meetingId, !this.muted);
 	};
 
 	private readonly onConnectionStateChange = (): void => {
@@ -135,6 +139,25 @@ export default class BidirectionalConnectionAudioInOut implements IBidirectional
 		});
 	}
 
+	/**
+	 * Replace the sender track with the given microphone stream, applying the
+	 * current muted state. The track is disabled before being attached to the
+	 * sender so that no audio frame can leak while muted, and the state is read
+	 * again once attached to honor a mute/unmute requested during acquisition.
+	 */
+	private applyAudioStream(stream: MediaStream): Promise<void> {
+		const streamTrack = first(stream.getAudioTracks());
+		if (streamTrack) {
+			streamTrack.enabled = !this.muted;
+		}
+		return this.updateLocalStreamTrack(stream).then(() => {
+			if (streamTrack) {
+				streamTrack.enabled = !this.muted;
+			}
+			useStore.getState().setLocalStreams(STREAM_TYPE.AUDIO, stream);
+		});
+	}
+
 	updateRemoteStreamAudio(): void {
 		if (this.oscillatorAudioTrack != null) {
 			const fragment = window!.top!.document.createDocumentFragment();
@@ -156,6 +179,9 @@ export default class BidirectionalConnectionAudioInOut implements IBidirectional
 	 * audio gap caused by A2DP ↔ HFP profile switching.
 	 */
 	muteAudioTrack(): void {
+		// The flag is set unconditionally so that an acquisition still in
+		// flight (e.g. init()) picks up the muted state when it resolves
+		this.muted = true;
 		if (this.rtpSender?.track) {
 			this.rtpSender.track.enabled = false;
 		}
@@ -163,15 +189,27 @@ export default class BidirectionalConnectionAudioInOut implements IBidirectional
 
 	/**
 	 * Unmute the audio track by re-enabling it if still alive,
-	 * or acquiring a new stream if the track was previously stopped.
+	 * or acquiring a new stream if the sender track is missing, ended or
+	 * still the oscillator placeholder (microphone never acquired yet).
 	 */
 	async unmuteAudioTrack(deviceId?: string): Promise<void> {
-		if (this.rtpSender?.track && this.rtpSender.track.readyState === 'live') {
-			this.rtpSender.track.enabled = true;
+		this.muted = false;
+		const track = this.rtpSender?.track;
+		if (track && track !== this.placeholderAudioTrack && track.readyState === 'live') {
+			track.enabled = true;
 		} else {
-			// Fallback: track was stopped or lost, acquire a new one
-			const stream = await getAudioStream(deviceId);
-			await this.updateLocalStreamTrack(stream);
+			// A concurrent acquisition (e.g. init() still in flight) is harmless:
+			// updateLocalStreamTrack always stops the previous sender track
+			try {
+				const stream = await getAudioStream(deviceId ?? this.selectedAudioDeviceId);
+				await this.applyAudioStream(stream);
+				if (deviceId) {
+					this.selectedAudioDeviceId = deviceId;
+				}
+			} catch (reason) {
+				this.muted = true;
+				throw reason;
+			}
 		}
 	}
 


### PR DESCRIPTION
# Fixes for review findings on PR #804

## Context: what PR #804 does

Bluetooth headphones (e.g. AirPods) use two audio profiles: **A2DP** (high quality, listen-only, active when the microphone is off) and **HFP** (lower quality, bidirectional, active when the microphone is on). The original code stopped and re-acquired the microphone track on every mute/unmute, forcing the OS to switch profiles each time — and during the switch (~1-2 seconds) **the user could not hear anyone**.

PR #804 fixes this by keeping the microphone track alive for the whole meeting: mute becomes `track.enabled = false` (silence is transmitted), unmute `track.enabled = true` (instant). The microphone is acquired right at join, even when joining muted, so the HFP profile is active from the start.

## What this PR resolves on top of it

The approach is correct, but the implementation had race conditions that this branch fixes:

**1. Risk of transmitting a 440 Hz tone to all participants.** Before the WebRTC negotiation completes, the sender uses a placeholder track generated by an oscillator (a tone generator, kept disabled). The new `unmuteAudioTrack` only checked that the track was "live" — and the oscillator always is. So if the user clicked unmute while the microphone acquisition was still in flight, or after it had failed (permission denied), **the oscillator got enabled: every participant would hear a continuous beep**. The fix keeps an immutable reference to the placeholder track and, when it is still attached to the sender, re-acquires the microphone instead of enabling it.

**2. User "muted forever" without knowing it.** When joining muted and clicking unmute while the initial microphone acquisition was still in flight, the `init()` callback — which used the state captured *at construction time* ("joined muted") — resolved afterwards and **disabled the track that had just been enabled**. Result: the server and the other participants saw the user as unmuted, but they transmitted silence, with no error signal. The fix introduces an internal `muted` state, updated by every mute/unmute and read at the moment async operations resolve, not when they start.

**3. Smaller but concrete issues:**
- Switching microphone from the dropdown while muted left the new track enabled for an instant before being disabled — a potential (tiny) audio leak while muted. It is now disabled *before* being attached to the sender.
- If the API call notifying the status change failed, the UI and the track ended up inconsistent (showing unmuted while actually muted, or vice versa). The local state is now rolled back.
- Unhandled promise rejections in the device switch and in the Picture-in-Picture toggle.
- The re-acquisition fallback did not update the store nor remember the selected device (on mobile it would have reset the microphone choice).

**4. Safety net for the future:** 6 regression tests on the class pinning down exactly these scenarios (oscillator never enabled, init/unmute race, muted join, dead track), plus rollback tests on the components.

In short: PR #804 fixes the Bluetooth audio gap; this branch makes sure it does so **without** introducing the oscillator beep and the muted-ghost user — the two scenarios that would have reached production with the first user clicking fast or denying the mic permission.

## Verification

- Type-check and lint clean
- Full test suite green: 211 files, 1749 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)