### PR TITLE
chore(deps): update dependency zextras/jenkins-lib-common to v4.1.4

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 library(
-    identifier: 'jenkins-lib-common@v4.1.4',
+    identifier: 'jenkins-lib-common@v4.2.0',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         remote: 'git@github.com:zextras/jenkins-lib-common.git',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 library(
-    identifier: 'jenkins-lib-common@v2.11.3',
+    identifier: 'jenkins-lib-common@v4.1.4',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         remote: 'git@github.com:zextras/jenkins-lib-common.git',


### PR DESCRIPTION
- Pin-only bump: `jenkins-lib-common` `v2.11.3` -> `v4.1.4`.
- Repo is already past the trunk-based branch-guard change (first tag v2.0.0) and the DinD->Buildah change (first tag v2.10.0); neither applies.
- `uiPipeline()` is called with no parameters — no `testScript` present, nothing to remove.
- No raw `docker` / `withDockerRegistry` calls in the Jenkinsfile.

Refs https://zextras.atlassian.net/browse/IN-1168